### PR TITLE
[#3] CI：合约测试 Job（编译 + 96 测试，约 2 分钟）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  # Job A — smart contracts: compile + full test suite.
+  # Job B (frontend) is added in #4.
+  contracts:
+    name: Contracts (compile + test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+          cache-dependency-path: scaffold-alchemy-main/yarn.lock
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+        working-directory: scaffold-alchemy-main
+
+      - name: Compile contracts
+        run: yarn hardhat:compile
+        working-directory: scaffold-alchemy-main
+
+      - name: Run contract tests
+        run: yarn hardhat:test
+        working-directory: scaffold-alchemy-main

--- a/scaffold-alchemy-main/packages/hardhat/hardhat.config.ts
+++ b/scaffold-alchemy-main/packages/hardhat/hardhat.config.ts
@@ -62,6 +62,11 @@ const config: HardhatUserConfig = {
       sepolia: etherscanApiKey || "",
     },
   },
+  gasReporter: {
+    // Local: `yarn hardhat:test` sets REPORT_GAS=true → report printed.
+    // CI: GitHub Actions always sets CI=true → disabled to keep the pipeline fast.
+    enabled: process.env.REPORT_GAS === "true" && process.env.CI !== "true",
+  },
 };
 
 export default config;


### PR DESCRIPTION
Closes #3

## 根因发现（重要）

旧 CI 从未运行的真正原因：**workflows 放在 `scaffold-alchemy-main/.github/workflows/`，而 GitHub 只识别仓库根目录的 `.github/workflows/`**。三个旧 workflow 文件 GitHub 根本看不到。

## 改动内容

- 新增仓库根目录 `.github/workflows/ci.yml`（Job A 合约）：
  - `setup-node@v4` + `cache: yarn`（指向嵌套的 `yarn.lock`）
  - `yarn install --immutable` → `hardhat compile` → `hardhat test`
- `hardhat.config.ts`：gas-reporter 默认在 v2 里是**开着的**，改为 `REPORT_GAS === "true" && CI !== "true"` —— 本地保留 gas 表格，CI 关闭提速

## 验证

- [x] 本地 `CI=true yarn hardhat:test`：**96 passing in 8s**，无 gas 表格
- [x] 本地常规模式 gas 表格正常

## 预期时长

安装（缓存命中）~60–90s + 编译 ~20s + 测试 ~10s ≈ **2 分钟**

> Job B（前端）在 #4。