### PR TITLE
[#5] 真实构建与部署流水线

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build
+
+# Real production build on every merge to main.
+# PRs only run the fast CI (ci.yml) — no next build there to stay under 5 minutes.
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    name: Build Frontend (next build)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+          cache-dependency-path: scaffold-alchemy-main/yarn.lock
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+        working-directory: scaffold-alchemy-main
+
+      - name: Build Next.js
+        run: yarn workspace @scaffold-alchemy/nextjs build
+        working-directory: scaffold-alchemy-main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to Sepolia
+
+# Manual trigger only. Secrets live in the `sepolia` GitHub environment —
+# no local .env required, no real keys anywhere in the repo.
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy Contracts
+    runs-on: ubuntu-latest
+    environment: sepolia
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+          cache-dependency-path: scaffold-alchemy-main/yarn.lock
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+        working-directory: scaffold-alchemy-main
+
+      - name: Compile contracts
+        run: yarn hardhat:compile
+        working-directory: scaffold-alchemy-main
+
+      - name: Deploy to Sepolia
+        run: yarn deploy:final
+        working-directory: scaffold-alchemy-main
+        env:
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+          ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
+          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}


### PR DESCRIPTION
Closes #5

## 改动内容

- 新增 `build.yml`：push 到 main 后跑**真实** `next build`（无 IGNORE_BUILD_ERROR，旧 CI 的开关已在 #1 删除）
- 重写 `deploy.yml`（仓库根目录，旧版在嵌套目录从未被 GitHub 发现）：
  - `workflow_dispatch` 手动触发
  - `environment: sepolia`，PRIVATE_KEY / ALCHEMY_API_KEY / ETHERSCAN_API_KEY 全部走 **GitHub Secrets**，无需本地 .env
  - 部署脚本已核实无交互、无硬编码参数（`01_deploy_nftlaunchpad.ts` 支持 MINT_PRICE_ETH / MAX_SUPPLY / MAX_PER_WALLET 环境变量覆盖）

## 依赖

- 需要 main 先合并 #3/#4（本 PR 的 CI 才有 workflows 可跑）
- 需要你在仓库 Settings → Environments → sepolia 配置 3 个 Secrets（或把仓库级 Secrets 建好）