### PR TITLE
[#12] 前端真实构建跑通：prisma generate 修复 + 清理 IGNORE 残留

### DIFF
--- a/scaffold-alchemy-main/packages/nextjs/package.json
+++ b/scaffold-alchemy-main/packages/nextjs/package.json
@@ -8,12 +8,12 @@
     "dev": "next dev -p 56900",
     "format": "prettier --write . '!(node_modules|.next|contracts)/**/*'",
     "lint": "next lint",
+    "postinstall": "prisma generate",
     "test": "vitest run",
     "test:watch": "vitest",
     "serve": "next start",
     "start": "next dev -p 56900",
-    "vercel": "vercel --build-env YARN_ENABLE_IMMUTABLE_INSTALLS=false --build-env ENABLE_EXPERIMENTAL_COREPACK=1 --build-env VERCEL_TELEMETRY_DISABLED=1",
-    "vercel:yolo": "vercel --build-env YARN_ENABLE_IMMUTABLE_INSTALLS=false --build-env ENABLE_EXPERIMENTAL_COREPACK=1 --build-env NEXT_PUBLIC_IGNORE_BUILD_ERROR=true --build-env VERCEL_TELEMETRY_DISABLED=1"
+    "vercel": "vercel --build-env YARN_ENABLE_IMMUTABLE_INSTALLS=false --build-env ENABLE_EXPERIMENTAL_COREPACK=1 --build-env VERCEL_TELEMETRY_DISABLED=1"
   },
   "dependencies": {
     "@account-kit/core": "^4.35.0",


### PR DESCRIPTION
Closes #12

## 根因

真实 `next build`（无 IGNORE 开关）失败：**`@prisma/client did not initialize yet`** —— 全新安装从未生成 Prisma client。旧 CI 的 `NEXT_PUBLIC_IGNORE_BUILD_ERROR=true` 一直掩盖着这个问题（又一个"CI 从未真实跑通"的证据）。

## 改动内容

1. `packages/nextjs/package.json`：新增 `postinstall: prisma generate` —— 每次 `yarn install` 自动生成 client，CI/新克隆开箱即用
2. 删除 `vercel:yolo` 脚本（它唯一的差异就是 IGNORE_BUILD_ERROR=true，现在按政策禁止任何吞错误开关）

## 验证（main 基线）

| 检查 | 结果 |
|------|------|
| `next build`（真实，无 IGNORE） | **EXIT 0** ✅（首次） |
| `tsc --noEmit` | 0 error |
| `vitest run` | 74/74 |
| `yarn install`（postinstall 生效） | 6.9s 完成 |

> 说明：构建时间约 1-2 分钟，仍在 PR CI 之外（build 只在 main 合并后跑，见 #5），本 PR 让这条流水线真正可用。