### PR TITLE
[#16] 文档与代码同步

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,5 +1,10 @@
 # NFT Launchpad Kit — 项目文档
 
+> ⚠️ **本文档为历史快照（v34，2026-05-10），部分内容已过时。**
+> 现状以代码和根目录 `README.md` 为准；开发流程见 `scaffold-alchemy-main/CONTRIBUTING.md`。
+> 已知差异：测试数现为 96 合约 + 74 前端 = 170；主合约约 1200 行；CI 已重写（见 `.github/workflows/`）。
+> 当前文档中"CI/CD ✅ 完成"等条目反映的是旧状态，实际 CI 于 2026-08 重建。
+
 > 最后更新：2026-05-10（v34 — 全 API 测试覆盖 + OpenAPI 文档 + Vercel 部署配置）
 
 ---
@@ -288,7 +293,7 @@ NFT_Launchpad_Kit/
     ├── packages/
     │   ├── hardhat/                  # 智能合约
     │   │   ├── contracts/
-    │   │   │   ├── NFTLaunchpadKit.sol   # 核心合约（~900 行，36 个事件，含 Phased Claim Conditions）
+    │   │   │   ├── NFTLaunchpadKit.sol   # 核心合约（~1200 行，29 个事件，含 Phased Claim Conditions）
     │   │   │   └── TestERC20.sol         # 测试代币
     │   │   ├── test/
     │   │   │   ├── NFTLaunchpadKit.advanced.ts  # 9 个核心测试

--- a/README.md
+++ b/README.md
@@ -32,47 +32,58 @@
 ## 快速开始
 
 ```bash
-# 安装依赖
+# 安装依赖（yarn 3，含 prisma generate）
+cd scaffold-alchemy-main
 yarn install
 
-# 启动本地区块链
-cd packages/hardhat
-npx hardhat node
+# 合约测试
+yarn hardhat:test          # 96 个合约测试
 
-# 部署合约
-npx hardhat deploy --network localhost
-
-# 启动前端
-cd packages/nextjs
-npm run dev
+# 前端（vitest / 类型检查 / lint）
+yarn workspace @scaffold-alchemy/nextjs test          # 74 个前端测试
+yarn workspace @scaffold-alchemy/nextjs check-types   # 类型检查
+yarn workspace @scaffold-alchemy/nextjs dev           # 本地开发（端口 56900）
 ```
+
+环境变量：复制根目录 `.env.example` 为 `.env` 并填写（Alchemy API Key 等）。
+开发流程、分支/PR 规范见 `scaffold-alchemy-main/CONTRIBUTING.md`。
 
 ## 测试
 
 ```bash
-cd packages/hardhat
+cd scaffold-alchemy-main
 
-# 运行全部 82 个测试
-npx hardhat test
+# 运行全部 96 个合约测试（本地附带 gas 报告；CI 中关闭以提速）
+yarn hardhat:test
 
-# Gas 报告
-npx hardhat test --grep "Gas"
+# 前端：74 个 Vitest 用例
+yarn workspace @scaffold-alchemy/nextjs test
 ```
+
+## CI（GitHub Actions）
+
+- `ci.yml`：PR 触发 —— 合约测试 + 前端类型/测试/lint 并行，约 3-4 分钟
+- `build.yml`：合并到 main 后真实 `next build`
+- `deploy.yml`：手动触发 Sepolia 部署（GitHub Secrets）
 
 ## 项目结构
 
 ```
+scaffold-alchemy-main/       # Yarn 3 工作区
 ├── packages/
-│   ├── hardhat/              # 智能合约
+│   ├── hardhat/             # 智能合约
 │   │   ├── contracts/
-│   │   │   ├── NFTLaunchpadKit.sol        # 主合约（~950 行）
+│   │   │   ├── NFTLaunchpadKit.sol        # 主合约（~1200 行，96 测试）
 │   │   │   └── NFTLaunchpadKitFactory.sol # Clone 工厂
-│   │   ├── test/             # 测试（82 个）
-│   │   └── deploy/           # 部署脚本
-│   └── nextjs/               # 前端
-│       ├── components/       # UI 组件
-│       ├── app/              # 页面路由
-│       └── utils/            # 工具库（Merkle、签名、错误映射）
+│   │   ├── test/            # 测试（96 个）
+│   │   └── deploy/          # 部署脚本
+│   ├── nextjs/              # 前端（74 个测试）
+│   │   ├── components/      # UI 组件
+│   │   ├── app/             # 页面路由 + API
+│   │   └── utils/           # 工具库（Merkle、签名、错误映射）
+│   └── subgraph/            # The Graph 子图
+└── GAS_BASELINE.md          # Gas 回归基准
+└── TEST_BASELINE.md         # 前端测试基线
 ```
 
 ## 技术栈

--- a/scaffold-alchemy-main/README.md
+++ b/scaffold-alchemy-main/README.md
@@ -1,4 +1,8 @@
-# 🏗 Scaffold-Alchemy
+# 🏗 Scaffold-Alchemy（本项目工作区）
+
+> 本目录是 NFT Launchpad Kit 的 Yarn 3 工作区（`packages/hardhat` + `packages/nextjs` + `packages/subgraph`）。
+> **项目文档见仓库根目录 `README.md`**；开发流程见本目录 `CONTRIBUTING.md`；测试基线见 `TEST_BASELINE.md` / `GAS_BASELINE.md`。
+> 下方为 scaffold 模板原始说明（保留备查）。
 
 Scaffold-Alchemy is a fork of the popular starter project [Scaffold-Eth 2](https://scaffoldeth.io/). It is everything you need to build dApps on Ethereum. You can get started immediately NextJS, TypeScript, Hardhat, AccountKit, Enhanced APIs and Subgraphs 🤩
 


### PR DESCRIPTION
Closes #16

## 改动内容

1. **根 README**（项目门面文档）：
   - 测试数：82 → **96 合约 + 74 前端 = 170**
   - 合约行数：~950 → ~1200
   - 快速开始改为 yarn 3 工作区命令（原 `npm run dev` 是错的）
   - 新增 CI 说明（ci/build/deploy 三个 workflow）
   - 项目结构图更新（含 subgraph、基线文档）
2. **PROJECT.md**：顶部加"历史快照（v34）"横幅，指向 README/CONTRIBUTING 为准；修正合约行数
3. **scaffold-alchemy-main/README.md**：加"本项目工作区"说明 + 指向上级文档（原来被误认为项目 README）

## 验证

- [x] 文档中数字与代码一致（96/74/170、1200 行）
- [x] 无"已完成但实际没有"的条目（PROJECT.md 已横幅声明为历史快照）