### PR TITLE
[infra] develop 分支流程：CI 适配 + 文档

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,10 @@
 name: Build
 
-# Real production build on every merge to main.
+# Real production build on every merge to main/develop.
 # PRs only run the fast CI (ci.yml) — no next build there to stay under 5 minutes.
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   # Job A — smart contracts: compile + full test suite.

--- a/README.md
+++ b/README.md
@@ -63,8 +63,14 @@ yarn workspace @scaffold-alchemy/nextjs test
 ## CI（GitHub Actions）
 
 - `ci.yml`：PR 触发 —— 合约测试 + 前端类型/测试/lint 并行，约 3-4 分钟
-- `build.yml`：合并到 main 后真实 `next build`
+- `build.yml`：合并到 main/develop 后真实 `next build`
 - `deploy.yml`：手动触发 Sepolia 部署（GitHub Secrets）
+
+## 分支模型
+
+- `main`：只做发布（develop → main 的 release PR，合并后打 tag）
+- `develop`：日常开发主线，feature 分支从这里拉出、PR 合入这里
+- 详细规范见 `scaffold-alchemy-main/CONTRIBUTING.md`
 
 ## 项目结构
 

--- a/scaffold-alchemy-main/CONTRIBUTING.md
+++ b/scaffold-alchemy-main/CONTRIBUTING.md
@@ -9,11 +9,17 @@
 
 ## 开发流程（核心约定）
 
-**一个 issue → 一个分支 → 一个 PR → CI 全绿 → 合并**
+**分支模型：`develop` 是开发主线，`main` 只做发布。**
+
+```
+feat/xxx ──► develop ──► main（发布 PR）
+```
 
 1. 所有改动必须先有 **issue**（功能/修复/文档均可），issue 里有验收标准。
-2. 分支命名：`feat/<issue号>-<英文短描述>`，例如 `feat/3-ci-contract-job`。
-3. 提交信息遵循 [Conventional Commits](https://www.conventionalcommits.org/)：
+2. **日常开发：分支从 `develop` 拉出，PR 合入 `develop`**（禁止直接推 `main`/`develop`）。
+3. 发布：`develop → main` 的 release PR（如 v1.0.0），合并后打 tag。
+4. 分支命名：`feat/<issue号>-<英文短描述>`，例如 `feat/3-ci-contract-job`。
+5. 提交信息遵循 [Conventional Commits](https://www.conventionalcommits.org/)：
    ```
    feat: 添加 xxx（#12）
    fix: 修复 xxx（#7）
@@ -21,12 +27,12 @@
    docs: 更新 xxx（#16）
    ci: 调整 xxx（#4）
    ```
-4. PR 标题格式：`[#issue号] 一句话描述`；PR 描述自动关联 issue（`Closes #N`）。
-5. **CI 全绿是合并的硬性条件**：
-   - 合约：编译 + 96 测试（`yarn hardhat:test`）
+6. PR 标题格式：`[#issue号] 一句话描述`；PR 描述自动关联 issue（`Closes #N`）。
+7. **CI 全绿是合并的硬性条件**：
+   - 合约：编译 + 99 测试（`yarn hardhat:test`）
    - 前端：`tsc --noEmit` 零错误 + 74 Vitest 用例 + lint 零 error
-   - 目标：PR CI ≤ 5 分钟（两个 Job 并行）。PR 阶段不跑 `next build`（合并到 main 后由 build workflow 跑真构建）。
-6. 合并策略：**squash merge**，保持 main 历史干净。
+   - 目标：PR CI ≤ 5 分钟（两个 Job 并行）。PR 阶段不跑 `next build`（合并到 main/develop 后由 build workflow 跑真构建）。
+8. 合并策略：**squash merge**，保持历史干净。
 
 ## 本地开发
 


### PR DESCRIPTION
按新分支模型：日常开发合入 develop，main 只做发布。

## 改动内容

- `ci.yml` / `build.yml`：触发条件增加 develop（push + PR）
- `CONTRIBUTING.md`：分支模型说明（feat → develop → main release PR；禁止直推 main/develop）
- `README.md`：新增"分支模型"章节

## 后续流程

- 新 issue 分支从 `develop` 拉出，PR 目标 `develop`
- 发布时开 `develop → main` 的 release PR + tag（对应 #17）