### PR TITLE
[#35] Agent 原生发行示例：agent 创建集合 + 签名授权 + 用户铸造

### DIFF
--- a/scaffold-alchemy-main/examples/agent/README.md
+++ b/scaffold-alchemy-main/examples/agent/README.md
@@ -1,0 +1,134 @@
+# 🤖 Agent-Native Issuance — 10-Minute Guide
+
+> **The agent issues. The user mints.** Your AI agent can create collections,
+> sign mint grants, and hand them to users — fully automated, fully on-chain.
+
+This guide takes you from zero to "my agent issued a membership card" in about
+10 minutes. No crypto background needed — everything you must understand is
+explained inline.
+
+---
+
+## What you're building
+
+Your agent (any program holding a key — a scheduler, a webhook, an LLM tool
+call, a game server) will:
+
+1. **Create a collection** (one transaction, ~2 seconds)
+2. **Become the trusted signer** (only its signatures can authorize mints)
+3. **Sign a mint grant** for a user (EIP-712, one-time UID, expiring)
+4. **User mints** with that grant — no approvals, no lists, no backend
+
+The result: **agent-driven issuance** — membership cards, quest rewards,
+gated access, credentials, coupons. Minted on demand, verifiable by anyone.
+
+```
+┌─────────┐  deployCollection()  ┌──────────────┐
+│  AGENT  │ ───────────────────► │  Collection  │
+│ (key)   │  setTrustedSigner()  │  (contract)  │
+└────┬────┘ ───────────────────► └──────┬───────┘
+     │  signTypedData() (off-chain)     │ verifies sig on-chain
+     ▼                                  ▼
+  grant (sig + uid) ────────────────► mintWithSignature712V2()
+                                       ▲
+                            user (wallet) pays + gets NFT
+```
+
+---
+
+## Prereqs
+
+- Node.js ≥ 18
+- This repo, with the workspace installed once:
+  ```bash
+  cd scaffold-alchemy-main
+  yarn install
+  ```
+
+## Run it (3 terminal commands)
+
+```bash
+# 1. Start a local blockchain (Hardhat)
+cd packages/hardhat
+npx hardhat node
+
+# 2. In a SECOND terminal: deploy the Factory + implementation
+cd scaffold-alchemy-main
+npx hardhat deploy --network localhost
+
+# 3. In a THIRD terminal: run the agent demo
+cd scaffold-alchemy-main/examples/agent
+npx tsx agent-issuance.ts
+```
+
+You'll see the agent create a collection, sign a grant, and the user mint:
+
+```
+[agent]  ✅ collection deployed at 0x… (owner: agent)
+[agent]  ✅ trusted signer = agent
+[agent]  ✅ grant signed — handing it to the user
+[user]   ✅ minted
+— summary —
+  token #0 owner: 0x…  (user: 0x…)
+  grant uid used: true (one-time — reuse will revert)
+✅ Agent-native issuance loop completed
+```
+
+---
+
+## Reading the code (5 minutes)
+
+Open `agent-issuance.ts`. It's one file, five steps, all [viem](https://viem.sh).
+
+| Step | What happens | The key idea |
+|------|-------------|--------------|
+| 1 | `deployCollection` on the Factory | One tx creates a full collection via a minimal-proxy clone (~371k gas). The agent becomes its owner. |
+| 2 | `setTrustedSigner(agent)` | After this, **only signatures from this agent can authorize mints**. The contract enforces it on-chain. |
+| 3 | `agent.signTypedData(...)` | This is the **off-chain** step — no gas, no tx. The agent issues a grant: `{minter, quantity, deadline, price, uid}` signed with EIP-712. The `uid` is a random one-time token so the same grant can never be replayed. |
+| 4 | `mintWithSignature712V2(...)` | The user submits the grant + signature. The contract verifies the signer is the trusted agent, the uid is unused, and the deadline hasn't passed — then mints. |
+| 5 | verify | `ownerOf(0)` is the user; `isSignatureUsed(uid)` is true (one-time). |
+
+### The one thing to understand: "trusted signer"
+
+Think of it as an **API key for issuing**. The agent's private key is the
+secret; its public address is registered in the contract. Anyone can present a
+signature, but only signatures that verify against the registered address
+mint anything. If you want to rotate agents, call `setTrustedSigner` with the
+new address — old signatures stop working instantly.
+
+### Turning this into agent features
+
+- **Quest rewards**: after your game/webhook confirms a task, have the agent
+  sign a grant (quantity = reward size) and send it to the player.
+- **Membership**: mint a collection per tier; the agent signs one grant per
+  purchase; expiry = `deadline`.
+- **Credentials**: `metadata`-rich collections + signature grants = verifiable
+  certificates issued by a bot.
+- **Multi-agent**: one contract, one trusted signer address — give each agent
+  its own address and rotate roles with `OPERATOR_ROLE`/ownership as needed.
+
+---
+
+## Going further
+
+- **Real network (Sepolia testnet)**: deploy via `yarn deploy:final` and point
+  `RPC_URL` at a Sepolia RPC. Same code, real network.
+- **Production**: the same signing flow is exposed as an API —
+  `POST /api/signature` (the agent's key lives in `SIGNER_PRIVATE_KEY`),
+  rate-limited and validated. Agents can call it like any web service.
+- **White-list phases**: see `setAllowlistMerkleRoot` + `mintAllowlist` for
+  Merkle-gated drops, and `setClaimConditions` for multi-phase sales.
+- **Contract source**: `packages/hardhat/contracts/NFTLaunchpadKit.sol`
+  (28 custom errors, 99 tests, Slither-reviewed).
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `ECONNREFUSED 127.0.0.1:8545` | The Hardhat node isn't running (step 1). |
+| `deployments/localhost/…` not found | Run step 2 (deploy) first. |
+| `BadSignature` revert | The contract's trusted signer ≠ the signing key. Check step 2 and the `AGENT_PRIVATE_KEY` you set. |
+| `SignatureExpired` | Your system clock is ahead of the chain's time, or you waited > 1h. Deadline is `now + 3600`. |
+
+> License: MIT. This example is a demo — for production, read the security
+> notes in the repo (mainnet deployment requires a professional audit).

--- a/scaffold-alchemy-main/examples/agent/agent-issuance.ts
+++ b/scaffold-alchemy-main/examples/agent/agent-issuance.ts
@@ -1,0 +1,172 @@
+/**
+ * Agent-native issuance demo — "the agent issues, the user mints"
+ *
+ * This script shows the full loop an AI agent can run on its own:
+ *
+ *   1. The AGENT creates a collection through the Factory
+ *   2. The AGENT configures it (itself as the trusted signer)
+ *   3. The AGENT signs a mint grant (EIP-712 V2 + one-time UID) for a user
+ *   4. The USER mints with that grant — no approvals, no lists, no backend
+ *
+ * The "agent" here is just a private key held by a program. Swap the key
+ * holder for any automation you like (scheduler, webhook, LLM tool call)
+ * and you have agent-driven issuance: membership cards, rewards, gated
+ * access, credentials — minted on demand.
+ *
+ * Prereqs (see README.md):
+ *   npx hardhat node            # local chain
+ *   npx hardhat deploy --network localhost   # deploys Factory + implementation
+ *
+ * Run:
+ *   yarn demo        (or: npx tsx agent-issuance.ts)
+ */
+import "dotenv/config";
+import {
+  createPublicClient,
+  createWalletClient,
+  http,
+  parseEther,
+  parseEventLogs,
+  toHex,
+} from "viem";
+import { hardhat } from "viem/chains";
+import { privateKeyToAccount } from "viem/accounts";
+import type { Abi, Address, Hex } from "viem";
+import { randomBytes } from "crypto";
+
+// Deployment artifacts written by hardhat-deploy on the local chain.
+import factoryDeployment from "../../packages/hardhat/deployments/localhost/NFTLaunchpadKitFactory.json";
+import kitDeployment from "../../packages/hardhat/deployments/localhost/NFTLaunchpadKit.json";
+
+// ---------------------------------------------------------------------------
+// Setup — two actors: an AGENT (a program holding a key) and a USER
+// ---------------------------------------------------------------------------
+
+async function main() {
+const rpcUrl = process.env.RPC_URL ?? "http://127.0.0.1:8545";
+
+// Defaults are Hardhat's well-known local test accounts (dev only, never mainnet).
+const agentKey = (process.env.AGENT_PRIVATE_KEY ??
+  "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d") as Hex;
+const userKey = (process.env.USER_PRIVATE_KEY ??
+  "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a") as Hex;
+
+const agent = privateKeyToAccount(agentKey); // the AI agent's wallet
+const user = privateKeyToAccount(userKey); // a human user's wallet
+
+const publicClient = createPublicClient({ chain: hardhat, transport: http(rpcUrl) });
+const agentWallet = createWalletClient({ account: agent, chain: hardhat, transport: http(rpcUrl) });
+const userWallet = createWalletClient({ account: user, chain: hardhat, transport: http(rpcUrl) });
+
+const factory = { address: factoryDeployment.address as Address, abi: factoryDeployment.abi as Abi } as const;
+const kitAbi = kitDeployment.abi as Abi;
+
+const MINT_PRICE = parseEther("0.01"); // collection price (ETH)
+
+// ---------------------------------------------------------------------------
+// Step 1 — the AGENT creates a collection (one tx, ~371k gas via clone)
+// ---------------------------------------------------------------------------
+
+console.log(`[agent]  ${agent.address.slice(0, 10)}… creating collection "Agent Club"…`);
+const createTx = await agentWallet.writeContract({
+  ...factory,
+  functionName: "deployCollection",
+  args: ["Agent Club", "AGT", 1000, 5, MINT_PRICE],
+});
+const createReceipt = await publicClient.waitForTransactionReceipt({ hash: createTx });
+const [cloneEvent] = parseEventLogs({
+  logs: createReceipt.logs,
+  abi: factory.abi,
+  eventName: "CollectionCloned",
+});
+const collection = cloneEvent.args.cloneAddress as Address;
+console.log(`[agent]  ✅ collection deployed at ${collection} (owner: agent)`);
+
+const kit = { address: collection, abi: kitAbi } as const;
+
+// ---------------------------------------------------------------------------
+// Step 2 — the AGENT configures the collection: itself is the trusted signer.
+// From here on, only signatures from this agent can authorize mints.
+// ---------------------------------------------------------------------------
+
+console.log("[agent]  configuring trusted signer…");
+await agentWallet.writeContract({
+  ...kit,
+  functionName: "setTrustedSigner",
+  args: [agent.address],
+});
+console.log("[agent]  ✅ trusted signer = agent");
+
+// ---------------------------------------------------------------------------
+// Step 3 — the AGENT signs a mint grant for the user.
+// EIP-712 V2: one-time global UID, per-grant price, 1-hour expiry.
+// ---------------------------------------------------------------------------
+
+const uid = toHex(randomBytes(32));
+const deadline = Math.floor(Date.now() / 1000) + 3600; // expires in 1h
+const grant = {
+  minter: user.address,
+  quantity: 1n,
+  maxMint: 5n, // max 5 total for this grant
+  deadline: BigInt(deadline),
+  pricePerToken: 0n, // 0 = use the collection's global price
+  uid,
+};
+
+console.log(`[agent]  signing mint grant for ${user.address.slice(0, 10)}… (uid ${uid.slice(0, 10)}…)`);
+const signature = await agent.signTypedData({
+  domain: { name: "NFT Launchpad Kit", version: "1", chainId: hardhat.id, verifyingContract: collection },
+  types: {
+    MintAuthorizationV2: [
+      { name: "minter", type: "address" },
+      { name: "quantity", type: "uint256" },
+      { name: "maxMint", type: "uint256" },
+      { name: "deadline", type: "uint256" },
+      { name: "pricePerToken", type: "uint256" },
+      { name: "uid", type: "bytes32" },
+    ],
+  },
+  primaryType: "MintAuthorizationV2",
+  message: grant,
+});
+console.log("[agent]  ✅ grant signed — handing it to the user");
+
+// ---------------------------------------------------------------------------
+// Step 4 — the USER mints using the agent's signature.
+// The contract verifies the signature on-chain and mints the NFT.
+// ---------------------------------------------------------------------------
+
+console.log(`[user]   minting with agent's signature…`);
+const mintTx = await userWallet.writeContract({
+  ...kit,
+  functionName: "mintWithSignature712V2",
+  args: [grant.quantity, grant.maxMint, grant.deadline, grant.pricePerToken, grant.uid, signature],
+  value: MINT_PRICE,
+});
+await publicClient.waitForTransactionReceipt({ hash: mintTx });
+console.log("[user]   ✅ minted");
+
+// ---------------------------------------------------------------------------
+// Step 5 — verify
+// ---------------------------------------------------------------------------
+
+const ownerOf0 = await publicClient.readContract({ ...kit, functionName: "ownerOf", args: [0n] });
+const supply = await publicClient.readContract({ ...kit, functionName: "totalSupply" });
+const uidUsed = await publicClient.readContract({ ...kit, functionName: "isSignatureUsed", args: [grant.uid] });
+
+console.log("\n— summary —");
+console.log(`  collection:    ${collection}`);
+console.log(`  total supply:  ${supply}`);
+console.log(`  token #0 owner:${ownerOf0}  (user: ${user.address})`);
+console.log(`  grant uid used:${uidUsed} (one-time — reuse will revert)`);
+
+if (ownerOf0.toLowerCase() !== user.address.toLowerCase()) {
+  throw new Error("verification failed: token #0 is not owned by the user");
+}
+console.log("\n✅ Agent-native issuance loop completed: agent created → agent signed → user minted");
+}
+
+main().catch(err => {
+  console.error("\n❌ demo failed:", err.message ?? err);
+  process.exit(1);
+});

--- a/scaffold-alchemy-main/examples/agent/agent-issuance.ts
+++ b/scaffold-alchemy-main/examples/agent/agent-issuance.ts
@@ -59,6 +59,21 @@ const agentWallet = createWalletClient({ account: agent, chain: hardhat, transpo
 const userWallet = createWalletClient({ account: user, chain: hardhat, transport: http(rpcUrl) });
 
 const factory = { address: factoryDeployment.address as Address, abi: factoryDeployment.abi as Abi } as const;
+
+// Minimal typed ABI for the event we care about (keeps parseEventLogs fully typed).
+const CollectionClonedAbi = [
+  {
+    type: "event",
+    name: "CollectionCloned",
+    inputs: [
+      { type: "address", name: "cloneAddress", indexed: true },
+      { type: "address", name: "owner", indexed: true },
+      { type: "string", name: "name" },
+      { type: "string", name: "symbol" },
+      { type: "uint256", name: "maxSupply" },
+    ],
+  },
+] as const;
 const kitAbi = kitDeployment.abi as Abi;
 
 const MINT_PRICE = parseEther("0.01"); // collection price (ETH)
@@ -76,7 +91,7 @@ const createTx = await agentWallet.writeContract({
 const createReceipt = await publicClient.waitForTransactionReceipt({ hash: createTx });
 const [cloneEvent] = parseEventLogs({
   logs: createReceipt.logs,
-  abi: factory.abi,
+  abi: CollectionClonedAbi,
   eventName: "CollectionCloned",
 });
 const collection = cloneEvent.args.cloneAddress as Address;
@@ -150,7 +165,11 @@ console.log("[user]   ✅ minted");
 // Step 5 — verify
 // ---------------------------------------------------------------------------
 
-const ownerOf0 = await publicClient.readContract({ ...kit, functionName: "ownerOf", args: [0n] });
+const ownerOf0 = (await publicClient.readContract({
+  ...kit,
+  functionName: "ownerOf",
+  args: [0n],
+})) as Address;
 const supply = await publicClient.readContract({ ...kit, functionName: "totalSupply" });
 const uidUsed = await publicClient.readContract({ ...kit, functionName: "isSignatureUsed", args: [grant.uid] });
 

--- a/scaffold-alchemy-main/examples/agent/package.json
+++ b/scaffold-alchemy-main/examples/agent/package.json
@@ -10,5 +10,9 @@
     "dotenv": "^16.5.0",
     "tsx": "^4.19.0",
     "viem": "^2.13.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "typescript": "^5.5.0"
   }
 }

--- a/scaffold-alchemy-main/examples/agent/package.json
+++ b/scaffold-alchemy-main/examples/agent/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "nla-agent-example",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Agent-native issuance example — an AI agent creates a collection and mints grants for users",
+  "scripts": {
+    "demo": "tsx agent-issuance.ts"
+  },
+  "dependencies": {
+    "dotenv": "^16.5.0",
+    "tsx": "^4.19.0",
+    "viem": "^2.13.0"
+  }
+}

--- a/scaffold-alchemy-main/examples/agent/tsconfig.json
+++ b/scaffold-alchemy-main/examples/agent/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "strict": true,

--- a/scaffold-alchemy-main/examples/agent/tsconfig.json
+++ b/scaffold-alchemy-main/examples/agent/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  }
+}

--- a/scaffold-alchemy-main/package.json
+++ b/scaffold-alchemy-main/package.json
@@ -5,7 +5,8 @@
   "workspaces": {
     "packages": [
       "packages/hardhat",
-      "packages/nextjs"
+      "packages/nextjs",
+      "examples/agent"
     ]
   },
   "scripts": {

--- a/scaffold-alchemy-main/yarn.lock
+++ b/scaffold-alchemy-main/yarn.lock
@@ -6974,6 +6974,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:^20":
+  version: 20.19.43
+  resolution: "@types/node@npm:20.19.43"
+  dependencies:
+    undici-types: ~6.21.0
+  checksum: c959b5d256b073da95aa1892acb071b487c2f652f98b2cb75e92657d51b99bd691aa811023fb13acd6752bc1bcb75dc579db02190a4da70926cf6f372011bc4e
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:^20.11.24":
   version: 20.19.40
   resolution: "@types/node@npm:20.19.40"
@@ -15819,8 +15828,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "nla-agent-example@workspace:examples/agent"
   dependencies:
+    "@types/node": ^20
     dotenv: ^16.5.0
     tsx: ^4.19.0
+    typescript: ^5.5.0
     viem: ^2.13.0
   languageName: unknown
   linkType: soft
@@ -19724,6 +19735,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:^5.5.0":
+  version: 5.9.3
+  resolution: "typescript@npm:5.9.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 0d0ffb84f2cd072c3e164c79a2e5a1a1f4f168e84cb2882ff8967b92afe1def6c2a91f6838fb58b168428f9458c57a2ba06a6737711fdd87a256bbe83e9a217f
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@4.9.5#~builtin<compat/typescript>":
   version: 4.9.5
   resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=a1c5e5"
@@ -19741,6 +19762,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: fc52962f31a5bcb716d4213bef516885e4f01f30cea797a831205fc9ef12b405a40561c40eae3127ab85ba1548e7df49df2bcdee6b84a94bfbe3a0d7eff16b14
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@^5.5.0#~builtin<compat/typescript>":
+  version: 5.9.3
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#~builtin<compat/typescript>::version=5.9.3&hash=a1c5e5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 8bb8d86819ac86a498eada254cad7fb69c5f74778506c700c2a712daeaff21d3a6f51fd0d534fe16903cb010d1b74f89437a3d02d4d0ff5ca2ba9a4660de8497
   languageName: node
   linkType: hard
 

--- a/scaffold-alchemy-main/yarn.lock
+++ b/scaffold-alchemy-main/yarn.lock
@@ -525,6 +525,188 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/aix-ppc64@npm:0.28.2"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/android-arm64@npm:0.28.2"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/android-arm@npm:0.28.2"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/android-x64@npm:0.28.2"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/darwin-arm64@npm:0.28.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/darwin-x64@npm:0.28.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/freebsd-arm64@npm:0.28.2"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/freebsd-x64@npm:0.28.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/linux-arm64@npm:0.28.2"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/linux-arm@npm:0.28.2"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/linux-ia32@npm:0.28.2"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/linux-loong64@npm:0.28.2"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/linux-mips64el@npm:0.28.2"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/linux-ppc64@npm:0.28.2"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/linux-riscv64@npm:0.28.2"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/linux-s390x@npm:0.28.2"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/linux-x64@npm:0.28.2"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/netbsd-arm64@npm:0.28.2"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/netbsd-x64@npm:0.28.2"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/openbsd-arm64@npm:0.28.2"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/openbsd-x64@npm:0.28.2"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openharmony-arm64@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/openharmony-arm64@npm:0.28.2"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/sunos-x64@npm:0.28.2"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/win32-arm64@npm:0.28.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-ia32@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/win32-ia32@npm:0.28.2"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.28.2":
+  version: 0.28.2
+  resolution: "@esbuild/win32-x64@npm:0.28.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.9.1":
   version: 4.9.1
   resolution: "@eslint-community/eslint-utils@npm:4.9.1"
@@ -11624,6 +11806,95 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild@npm:~0.28.0":
+  version: 0.28.2
+  resolution: "esbuild@npm:0.28.2"
+  dependencies:
+    "@esbuild/aix-ppc64": 0.28.2
+    "@esbuild/android-arm": 0.28.2
+    "@esbuild/android-arm64": 0.28.2
+    "@esbuild/android-x64": 0.28.2
+    "@esbuild/darwin-arm64": 0.28.2
+    "@esbuild/darwin-x64": 0.28.2
+    "@esbuild/freebsd-arm64": 0.28.2
+    "@esbuild/freebsd-x64": 0.28.2
+    "@esbuild/linux-arm": 0.28.2
+    "@esbuild/linux-arm64": 0.28.2
+    "@esbuild/linux-ia32": 0.28.2
+    "@esbuild/linux-loong64": 0.28.2
+    "@esbuild/linux-mips64el": 0.28.2
+    "@esbuild/linux-ppc64": 0.28.2
+    "@esbuild/linux-riscv64": 0.28.2
+    "@esbuild/linux-s390x": 0.28.2
+    "@esbuild/linux-x64": 0.28.2
+    "@esbuild/netbsd-arm64": 0.28.2
+    "@esbuild/netbsd-x64": 0.28.2
+    "@esbuild/openbsd-arm64": 0.28.2
+    "@esbuild/openbsd-x64": 0.28.2
+    "@esbuild/openharmony-arm64": 0.28.2
+    "@esbuild/sunos-x64": 0.28.2
+    "@esbuild/win32-arm64": 0.28.2
+    "@esbuild/win32-ia32": 0.28.2
+    "@esbuild/win32-x64": 0.28.2
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 724788c38454e29cd2dc930f02e593dd9c21ef1c977bba89664b6be16c80c83494d367961b8425a65d41d5a2245d2b1b3e5d21ed41333f6e2dbe1bc83526a62b
+  languageName: node
+  linkType: hard
+
 "escalade@npm:^3.1.1, escalade@npm:^3.2.0":
   version: 3.2.0
   resolution: "escalade@npm:3.2.0"
@@ -15544,6 +15815,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nla-agent-example@workspace:examples/agent":
+  version: 0.0.0-use.local
+  resolution: "nla-agent-example@workspace:examples/agent"
+  dependencies:
+    dotenv: ^16.5.0
+    tsx: ^4.19.0
+    viem: ^2.13.0
+  languageName: unknown
+  linkType: soft
+
 "node-addon-api@npm:^2.0.0":
   version: 2.0.2
   resolution: "node-addon-api@npm:2.0.2"
@@ -16072,6 +16353,27 @@ __metadata:
     typescript:
       optional: true
   checksum: 75adc672d5f61918abda1d4b9ac8278a99c50f8684c858d88e8051202d9af5331edfce903ee53a24cfef463af6b3fd2202fc7b5b018d1bf088e1e67e71e7e8ed
+  languageName: node
+  linkType: hard
+
+"ox@npm:0.14.34":
+  version: 0.14.34
+  resolution: "ox@npm:0.14.34"
+  dependencies:
+    "@adraffy/ens-normalize": ^1.11.0
+    "@noble/ciphers": ^1.3.0
+    "@noble/curves": 1.9.1
+    "@noble/hashes": ^1.8.0
+    "@scure/bip32": ^1.7.0
+    "@scure/bip39": ^1.6.0
+    abitype: ^1.2.3
+    eventemitter3: 5.0.1
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: d28aa24b20b784b0918736100496033ea3062e1ea426dde79cdcbefd69a83ebbd712333a2a20f19ad42e593e8fce5253dae91e7686997e9b79b07aee3865412e
   languageName: node
   linkType: hard
 
@@ -19213,6 +19515,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tsx@npm:^4.19.0":
+  version: 4.23.12
+  resolution: "tsx@npm:4.23.12"
+  dependencies:
+    esbuild: ~0.28.0
+    fsevents: ~2.3.3
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    tsx: dist/cli.mjs
+  checksum: f895395574f25ec987470944070828475ba6f5cb2ff565d203408bb60d4b0e62da6c223071c565f87687dc461b38a50886399feca1cf9b250bcfabd1ada20938
+  languageName: node
+  linkType: hard
+
 "tsyringe@npm:^4.8.0":
   version: 4.10.0
   resolution: "tsyringe@npm:4.10.0"
@@ -20096,6 +20413,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"viem@npm:^2.13.0":
+  version: 2.56.0
+  resolution: "viem@npm:2.56.0"
+  dependencies:
+    "@noble/curves": 1.9.1
+    "@noble/hashes": 1.8.0
+    "@scure/bip32": 1.7.0
+    "@scure/bip39": 1.6.0
+    abitype: 1.2.3
+    isows: 1.0.7
+    ox: 0.14.34
+    ws: 8.21.0
+  peerDependencies:
+    typescript: ">=5.0.4"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 8d7d1e2dd0bbda75eb972414b24e15fe21b1724083a21dcf04b046773bec5cda740204dbc70783d1e6dc190734424a59e8d628e32a3b0291873f80f13ea16ce0
+  languageName: node
+  linkType: hard
+
 "vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
   version: 8.0.11
   resolution: "vite@npm:8.0.11"
@@ -20634,6 +20972,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: d64ef1631227bd0c5fe21b3eb3646c9c91229402fb963d12d87b49af0a1ef757277083af23a5f85742bae1e520feddfb434cb882ea59249b15673c16dc3f36e0
+  languageName: node
+  linkType: hard
+
+"ws@npm:8.21.0":
+  version: 8.21.0
+  resolution: "ws@npm:8.21.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 83ff89ae011bc5c3c5605a45a0d50e12589143c7500ca4de83a8d43b3cd26e71f422cb3206fd1a9e6d541d666eeb66255c30d095d62d413b3c7afe5d2c5cb928
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #35

> AI 原生方向的第一块拼图。目标读者：**agent 开发者**（零币圈背景可上手）。

## 核心洞察

合约里的 `trustedSigner` + `mintWithSignature712V2`（UID 一次性签名）本来就是 **"程序签发、用户铸造"** 的 agent 原语 —— 签名者不必是人。这个 PR 把它变成可运行、可传播的演示。

## 改动内容

1. **`examples/agent/agent-issuance.ts`**（viem 纯前端、单文件、可运行）：
   - agent 通过 Factory 创建集合（clone，~371k gas）→ 自设为 trustedSigner
   - agent 签发 EIP-712 V2 铸造授权（一次性 UID + 1 小时过期）
   - 用户凭授权铸造 → 链上验证所有权 + UID 一次性
2. **`examples/agent/README.md`**：10 分钟上手指南 —— "agent = 持钥程序"框架、trusted-signer 类比 API key、任务奖励/会员/凭证三个落地配方
3. `examples/agent` 加入 yarn workspaces

## 实测（本地 Hardhat 链端到端）

```
[agent]  ✅ collection deployed at 0xCafac3… (owner: agent)
[agent]  ✅ trusted signer = agent
[agent]  ✅ grant signed — handing it to the user
[user]   ✅ minted
— summary —
  token #0 owner: 0x3C44CdDd…  (user)   ✅
  grant uid used: true (one-time)       ✅
```

## 后续

- **#40**（Agent 身份注册 API）—— 产品层，让 agent 可注册身份/能力/授权历史
- **#36** 打通：AI 生图 → IPFS → 集合，与 agent 流程串联