### PR TITLE
[#34] 一键创建集合：无代码发布向导（Factory 部署 + 平台注册）

### DIFF
--- a/scaffold-alchemy-main/packages/nextjs/__tests__/api/collections.test.ts
+++ b/scaffold-alchemy-main/packages/nextjs/__tests__/api/collections.test.ts
@@ -176,4 +176,60 @@ describe("POST /api/collections", () => {
     expect(res.status).toBe(201);
     expect(mockCreate).toHaveBeenCalledTimes(2); // user + collection
   });
+
+  it("links contractAddress + chainId when created via the Factory wizard", async () => {
+    const fakeUser = { id: "user-1", address: "0x1234" };
+    mockFindUnique.mockResolvedValueOnce(fakeUser);
+    mockCreate.mockResolvedValueOnce({ id: "col-1" });
+
+    const res = await POST(
+      makePostRequest({
+        name: "Agent Club",
+        symbol: "AGT",
+        maxSupply: 1000,
+        mintPrice: "10000000000000000",
+        ownerAddress: "0x1234",
+        contractAddress: "0xAbC1234567890123456789012345678901234567",
+        chainId: 31337,
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    const createData = mockCreate.mock.calls[0][0].data;
+    expect(createData.contractAddress).toBe("0xabc1234567890123456789012345678901234567"); // lowercased
+    expect(createData.chainId).toBe(31337);
+  });
+
+  it("rejects an invalid contract address", async () => {
+    const res = await POST(
+      makePostRequest({
+        name: "T",
+        symbol: "T",
+        maxSupply: 1,
+        mintPrice: "1",
+        ownerAddress: "0x1234",
+        contractAddress: "not-an-address",
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain("Invalid contract address");
+  });
+
+  it("defaults chainId to 11155111 (Sepolia) when absent", async () => {
+    mockFindUnique.mockResolvedValueOnce({ id: "user-1", address: "0x1234" });
+    mockCreate.mockResolvedValueOnce({ id: "col-1" });
+
+    await POST(
+      makePostRequest({
+        name: "T",
+        symbol: "T",
+        maxSupply: 1,
+        mintPrice: "1",
+        ownerAddress: "0x1234",
+      }),
+    );
+
+    expect(mockCreate.mock.calls[0][0].data.chainId).toBe(11155111);
+  });
 });

--- a/scaffold-alchemy-main/packages/nextjs/app/admin/page.tsx
+++ b/scaffold-alchemy-main/packages/nextjs/app/admin/page.tsx
@@ -5,6 +5,7 @@ import { formatEther, parseEther } from "viem";
 import { useAccount } from "wagmi";
 import { AdminCharts } from "~~/components/AdminCharts";
 import { AdminCollectionSelector } from "~~/components/AdminCollectionSelector";
+import CreateCollection from "~~/components/CreateCollection";
 import { AdminDashboard } from "~~/components/AdminDashboard";
 import { AdminEventLog } from "~~/components/AdminEventLog";
 import { WhitelistManager } from "~~/components/WhitelistManager";
@@ -70,9 +71,10 @@ function ConfirmDialog({
   );
 }
 
-type Tab = "sale" | "auction" | "whitelist" | "royalty" | "payout" | "signer" | "erc20" | "withdraw";
+type Tab = "create" | "sale" | "auction" | "whitelist" | "royalty" | "payout" | "signer" | "erc20" | "withdraw";
 
 const TABS: { key: Tab; icon: string; label: string; desc: string }[] = [
+  { key: "create", icon: "🚀", label: "创建集合", desc: "No-code wizard — deploy a new collection via the Factory" },
   { key: "sale", icon: "⚡", label: "Sale Control", desc: "Toggle sale states, price, limits, metadata" },
   { key: "auction", icon: "📉", label: "Dutch Auction", desc: "Configure auction pricing parameters" },
   { key: "whitelist", icon: "📋", label: "Whitelist", desc: "Manage Merkle root for allowlist" },
@@ -296,6 +298,15 @@ export default function AdminPage() {
             </h2>
             <p className="text-sm text-base-content/40 mt-0.5">{meta.desc}</p>
           </div>
+
+          {tab === "create" && (
+            <CreateCollection
+              onCreated={id => {
+                setSelectedCollection(id);
+                setTab("sale");
+              }}
+            />
+          )}
 
           {tab === "sale" && (
             <div className="space-y-5">

--- a/scaffold-alchemy-main/packages/nextjs/app/api/collections/route.ts
+++ b/scaffold-alchemy-main/packages/nextjs/app/api/collections/route.ts
@@ -73,10 +73,27 @@ export async function POST(req: NextRequest) {
   }
 
   const body = await req.json();
-  const { name, symbol, description, maxSupply, mintPrice, maxPerWallet, ownerAddress, coverImage } = body;
+  const {
+    name,
+    symbol,
+    description,
+    maxSupply,
+    mintPrice,
+    maxPerWallet,
+    ownerAddress,
+    coverImage,
+    contractAddress,
+    chainId,
+  } = body;
 
   if (!name || !symbol || !maxSupply || !mintPrice || !ownerAddress) {
     return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+  }
+
+  // Optional: link a deployed contract (creator-wizard flow, see #34).
+  // When present, the address must be a valid 0x… checksummed/hex address.
+  if (contractAddress && !/^0x[a-fA-F0-9]{40}$/.test(contractAddress)) {
+    return NextResponse.json({ error: "Invalid contract address" }, { status: 400 });
   }
 
   let user = await prisma.user.findUnique({ where: { address: ownerAddress.toLowerCase() } });
@@ -93,6 +110,8 @@ export async function POST(req: NextRequest) {
       mintPrice: mintPrice.toString(),
       maxPerWallet: maxPerWallet || 5,
       coverImage,
+      contractAddress: contractAddress ? contractAddress.toLowerCase() : null,
+      chainId: chainId || 11155111,
       ownerId: user.id,
     },
   });

--- a/scaffold-alchemy-main/packages/nextjs/components/CreateCollection.tsx
+++ b/scaffold-alchemy-main/packages/nextjs/components/CreateCollection.tsx
@@ -1,0 +1,346 @@
+"use client";
+
+/**
+ * CreateCollection — no-code collection creator wizard (#34).
+ *
+ * Flow (borrowed from the thirdweb dashboard pattern):
+ *   1. Basic info (name, symbol, supply, price, cover image via IPFS)
+ *   2. Deploy on-chain via the NFTLaunchpadKitFactory (browser wallet signs)
+ *   3. Register the collection in the platform backend
+ *   4. Guided next steps (sale / royalty / whitelist)
+ */
+import { useEffect, useMemo, useState } from "react";
+import { useAccount, useChainId, useWriteContract, useWaitForTransactionReceipt } from "wagmi";
+import { parseEther, parseEventLogs } from "viem";
+import type { Address } from "viem";
+import deployedContracts from "~~/contracts/deployedContracts";
+
+interface CreateCollectionProps {
+  /** Called after the collection is deployed + registered. */
+  onCreated: (collectionId: string) => void;
+}
+
+const STEPS = ["基本信息", "链上部署", "平台注册", "完成"];
+
+export default function CreateCollection({ onCreated }: CreateCollectionProps) {
+  const { address, isConnected } = useAccount();
+  const chainId = useChainId();
+  const factory = useMemo(
+    () => (deployedContracts as Record<number, any>)?.[chainId]?.NFTLaunchpadKitFactory,
+    [chainId],
+  );
+
+  const [step, setStep] = useState(0);
+  const [name, setName] = useState("");
+  const [symbol, setSymbol] = useState("");
+  const [maxSupply, setMaxSupply] = useState("1000");
+  const [maxPerWallet, setMaxPerWallet] = useState("5");
+  const [mintPrice, setMintPrice] = useState("0.01");
+  const [description, setDescription] = useState("");
+  const [coverImage, setCoverImage] = useState("");
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [cloneAddress, setCloneAddress] = useState<string | null>(null);
+  const [collectionId, setCollectionId] = useState<string | null>(null);
+
+  const { writeContractAsync, isPending: isDeploying } = useWriteContract();
+  const [deployTxHash, setDeployTxHash] = useState<`0x${string}` | null>(null);
+  const { data: deployReceipt, isError: deployFailed } = useWaitForTransactionReceipt({
+    hash: deployTxHash ?? undefined,
+  });
+
+  // Typed minimal ABI for the event we parse (keeps parseEventLogs fully typed).
+  const CollectionClonedAbi = [
+    {
+      type: "event",
+      name: "CollectionCloned",
+      inputs: [
+        { type: "address", name: "cloneAddress", indexed: true },
+        { type: "address", name: "owner", indexed: true },
+        { type: "string", name: "name" },
+        { type: "string", name: "symbol" },
+        { type: "uint256", name: "maxSupply" },
+      ],
+    },
+  ] as const;
+
+  // When the deploy tx confirms, parse the CollectionCloned event → clone address.
+  useEffect(() => {
+    if (!deployReceipt || step !== 1) return;
+    try {
+      const [cloneEvent] = parseEventLogs({
+        logs: deployReceipt.logs,
+        abi: CollectionClonedAbi,
+        eventName: "CollectionCloned",
+      });
+      if (!cloneEvent) throw new Error("部署成功但未找到 CollectionCloned 事件");
+      const addr = (cloneEvent.args as any).cloneAddress as string;
+      setCloneAddress(addr);
+      setStep(2);
+    } catch (e: any) {
+      setError(e?.message || "解析部署事件失败");
+    }
+  }, [deployReceipt, step, factory]);
+
+  // Deploy tx failed on-chain.
+  useEffect(() => {
+    if (deployFailed) setError("部署交易失败，请重试或检查钱包");
+  }, [deployFailed]);
+
+  const isValid = useMemo(
+    () =>
+      name.trim().length > 0 &&
+      symbol.trim().length > 0 &&
+      Number(maxSupply) > 0 &&
+      Number(maxPerWallet) > 0 &&
+      Number(mintPrice) > 0,
+    [name, symbol, maxSupply, maxPerWallet, mintPrice],
+  );
+
+  async function handleUpload() {
+    if (!coverImage) return;
+    setUploading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/ipfs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: name || "collection", description, image: coverImage }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "upload failed");
+      setCoverImage(data.ipfsUrl || coverImage);
+    } catch (e: any) {
+      setError(e.message || "图片上传失败");
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  async function handleDeploy() {
+    setError(null);
+    if (!address || !factory) return;
+    try {
+      const txHash = await writeContractAsync({
+        address: factory.address as Address,
+        abi: factory.abi,
+        functionName: "deployCollection",
+        args: [name.trim(), symbol.trim(), Number(maxSupply), Number(maxPerWallet), parseEther(mintPrice)],
+      });
+      setDeployTxHash(txHash);
+    } catch (e: any) {
+      setError(e?.shortMessage || e?.message || "部署失败（请检查钱包是否已连接/网络是否正确）");
+    }
+  }
+
+  async function handleRegister() {
+    setError(null);
+    if (!address || !cloneAddress) return;
+    try {
+      const res = await fetch("/api/collections", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          symbol: symbol.trim(),
+          description: description.trim() || undefined,
+          maxSupply: Number(maxSupply),
+          mintPrice,
+          maxPerWallet: Number(maxPerWallet),
+          ownerAddress: address,
+          coverImage: coverImage || undefined,
+          contractAddress: cloneAddress,
+          chainId,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "注册失败");
+      setCollectionId(data.id);
+      setStep(3);
+      onCreated(data.id);
+    } catch (e: any) {
+      setError(e.message || "注册失败");
+    }
+  }
+
+  return (
+    <div className="card bg-base-100 border border-base-300 shadow-lg">
+      <div className="card-body">
+        {/* Step indicator */}
+        <ul className="steps steps-horizontal w-full mb-6 text-sm">
+          {STEPS.map((label, i) => (
+            <li key={label} className={`step ${i <= step ? "step-primary" : ""}`}>
+              {label}
+            </li>
+          ))}
+        </ul>
+
+        {error && (
+          <div className="alert alert-error text-sm mb-4">
+            <span>⚠️ {error}</span>
+          </div>
+        )}
+
+        {/* Step 1 — basic info */}
+        {step === 0 && (
+          <div className="space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <label className="form-control">
+                <span className="label-text">集合名称 *</span>
+                <input
+                  className="input input-bordered"
+                  value={name}
+                  onChange={e => setName(e.target.value)}
+                  placeholder="例如：Agent Club"
+                />
+              </label>
+              <label className="form-control">
+                <span className="label-text">符号 *</span>
+                <input
+                  className="input input-bordered"
+                  value={symbol}
+                  onChange={e => setSymbol(e.target.value.toUpperCase())}
+                  placeholder="例如：AGT"
+                  maxLength={8}
+                />
+              </label>
+              <label className="form-control">
+                <span className="label-text">总供应量 *</span>
+                <input
+                  type="number"
+                  min={1}
+                  className="input input-bordered"
+                  value={maxSupply}
+                  onChange={e => setMaxSupply(e.target.value)}
+                />
+              </label>
+              <label className="form-control">
+                <span className="label-text">每钱包限购 *</span>
+                <input
+                  type="number"
+                  min={1}
+                  className="input input-bordered"
+                  value={maxPerWallet}
+                  onChange={e => setMaxPerWallet(e.target.value)}
+                />
+              </label>
+              <label className="form-control">
+                <span className="label-text">铸造价格（ETH）*</span>
+                <input
+                  type="number"
+                  min={0}
+                  step="0.0001"
+                  className="input input-bordered"
+                  value={mintPrice}
+                  onChange={e => setMintPrice(e.target.value)}
+                />
+              </label>
+              <label className="form-control">
+                <span className="label-text">封面图 URL（可选，支持 IPFS）</span>
+                <div className="flex gap-2">
+                  <input
+                    className="input input-bordered flex-1"
+                    value={coverImage}
+                    onChange={e => setCoverImage(e.target.value)}
+                    placeholder="https://… 或 ipfs://…"
+                  />
+                  <button className="btn btn-outline" onClick={handleUpload} disabled={uploading || !coverImage}>
+                    {uploading ? "上传中…" : "上传 IPFS"}
+                  </button>
+                </div>
+              </label>
+            </div>
+            <label className="form-control">
+              <span className="label-text">描述（可选）</span>
+              <textarea className="textarea textarea-bordered" value={description} onChange={e => setDescription(e.target.value)} rows={2} />
+            </label>
+            <div className="flex justify-end gap-2">
+              <button className="btn btn-primary" disabled={!isValid} onClick={() => setStep(1)}>
+                下一步：链上部署 →
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Step 2 — deploy via Factory */}
+        {step === 1 && (
+          <div className="space-y-4">
+            <div className="alert alert-info text-sm">
+              <span>
+                即将通过 Factory 部署集合 <b>{name || "—"}</b>（{symbol}）：
+                {Number(maxSupply)} 个 · {mintPrice} ETH · 每钱包 {maxPerWallet} 个。
+                部署 Gas 约 371k（最小代理克隆，比全量部署省 93%）。请用浏览器钱包确认交易。
+              </span>
+            </div>
+            {!isConnected && <div className="alert alert-warning text-sm">请先连接钱包（右上角 Connect 按钮）。</div>}
+            {isConnected && !factory && (
+              <div className="alert alert-warning text-sm">当前网络（chainId {chainId}）没有配置 Factory，请切换到 Sepolia 或本地链。</div>
+            )}
+            <div className="flex justify-end gap-2">
+              <button className="btn" onClick={() => setStep(0)}>
+                ← 返回
+              </button>
+              <button className="btn btn-primary" disabled={!isConnected || !factory || isDeploying} onClick={handleDeploy}>
+                {isDeploying ? "部署中…" : "🚀 部署集合"}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Step 3 — register in backend */}
+        {step === 2 && cloneAddress && (
+          <div className="space-y-4">
+            <div className="alert alert-success text-sm">
+              <span>
+                ✅ 合约已部署：<code className="break-all">{cloneAddress}</code>
+              </span>
+            </div>
+            <div className="alert alert-info text-sm">
+              <span>最后一步：把集合注册到平台（记录所有权、展示在集合页和管理后台）。</span>
+            </div>
+            <div className="flex justify-end gap-2">
+              <button className="btn btn-primary" onClick={handleRegister}>
+                注册到平台 →
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Step 4 — done + guided next steps */}
+        {step === 3 && collectionId && (
+          <div className="space-y-4">
+            <div className="alert alert-success text-sm">
+              <span>🎉 集合「{name}」创建成功！已切换到新集合的管理面板。</span>
+            </div>
+            <div className="text-sm text-base-content/70">
+              接下来可以：
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm">
+              <div className="border border-base-300 rounded-xl p-3">
+                <div className="font-bold mb-1">⚡ 开启销售</div>
+                <div className="text-base-content/50 text-xs mb-2">设置价格、开关公开/白名单销售</div>
+                <button className="btn btn-sm btn-outline w-full" onClick={() => onCreated(collectionId)}>
+                  去 Sale Control
+                </button>
+              </div>
+              <div className="border border-base-300 rounded-xl p-3">
+                <div className="font-bold mb-1">💰 设置版税</div>
+                <div className="text-base-content/50 text-xs mb-2">EIP-2981 版税接收地址和比例</div>
+                <button className="btn btn-sm btn-outline w-full" onClick={() => onCreated(collectionId)}>
+                  去 Royalty
+                </button>
+              </div>
+              <div className="border border-base-300 rounded-xl p-3">
+                <div className="font-bold mb-1">📋 白名单</div>
+                <div className="text-base-content/50 text-xs mb-2">CSV 上传 → Merkle Root → 白名单铸造</div>
+                <button className="btn btn-sm btn-outline w-full" onClick={() => onCreated(collectionId)}>
+                  去 Whitelist
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/scaffold-alchemy-main/packages/nextjs/contracts/deployedContracts.ts
+++ b/scaffold-alchemy-main/packages/nextjs/contracts/deployedContracts.ts
@@ -2160,6 +2160,31 @@ const deployedContracts = {
 ]
       ,
     },
+    NFTLaunchpadKitFactory: {
+      address: "0x1e320041d3106022965C7846EE7bcbceab65a8e1",
+      abi: [{"inputs":[{"internalType":"address","name":"_implementation","type":"address"},{"internalType":"address","name":"_owner","type":"address"}],"stateMutability":"nonpayable","type":"constructor"},
+        {"inputs":[],"name":"DeploymentFailed","type":"error"},
+        {"inputs":[],"name":"FailedDeployment","type":"error"},
+        {"inputs":[{"internalType":"uint256","name":"balance","type":"uint256"},{"internalType":"uint256","name":"needed","type":"uint256"}],"name":"InsufficientBalance","type":"error"},
+        {"inputs":[{"internalType":"address","name":"owner","type":"address"}],"name":"OwnableInvalidOwner","type":"error"},
+        {"inputs":[{"internalType":"address","name":"account","type":"address"}],"name":"OwnableUnauthorizedAccount","type":"error"},
+        {"inputs":[],"name":"ZeroAddress","type":"error"},
+        {"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"cloneAddress","type":"address"},{"indexed":true,"internalType":"address","name":"owner","type":"address"},{"indexed":false,"internalType":"string","name":"name","type":"string"},{"indexed":false,"internalType":"string","name":"symbol","type":"string"},{"indexed":false,"internalType":"uint256","name":"maxSupply","type":"uint256"}],"name":"CollectionCloned","type":"event"},
+        {"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"previousOwner","type":"address"},{"indexed":true,"internalType":"address","name":"newOwner","type":"address"}],"name":"OwnershipTransferred","type":"event"},
+        {"inputs":[{"internalType":"uint256","name":"","type":"uint256"}],"name":"allCollections","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},
+        {"inputs":[{"internalType":"string","name":"name_","type":"string"},{"internalType":"string","name":"symbol_","type":"string"},{"internalType":"uint256","name":"maxSupply","type":"uint256"},{"internalType":"uint256","name":"maxPerWallet","type":"uint256"},{"internalType":"uint256","name":"mintPrice","type":"uint256"}],"name":"deployCollection","outputs":[{"internalType":"address","name":"clone","type":"address"}],"stateMutability":"nonpayable","type":"function"},
+        {"inputs":[{"internalType":"bytes32","name":"salt","type":"bytes32"},{"internalType":"string","name":"name_","type":"string"},{"internalType":"string","name":"symbol_","type":"string"},{"internalType":"uint256","name":"maxSupply","type":"uint256"},{"internalType":"uint256","name":"maxPerWallet","type":"uint256"},{"internalType":"uint256","name":"mintPrice","type":"uint256"}],"name":"deployCollectionDeterministic","outputs":[{"internalType":"address","name":"clone","type":"address"}],"stateMutability":"nonpayable","type":"function"},
+        {"inputs":[{"internalType":"uint256","name":"offset","type":"uint256"},{"internalType":"uint256","name":"limit","type":"uint256"}],"name":"getAllCollections","outputs":[{"internalType":"address[]","name":"","type":"address[]"}],"stateMutability":"view","type":"function"},
+        {"inputs":[],"name":"getCollectionCount","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},
+        {"inputs":[{"internalType":"address","name":"_owner","type":"address"}],"name":"getCollectionsByOwner","outputs":[{"internalType":"address[]","name":"","type":"address[]"}],"stateMutability":"view","type":"function"},
+        {"inputs":[],"name":"implementation","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},
+        {"inputs":[],"name":"owner","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},
+        {"inputs":[{"internalType":"address","name":"","type":"address"},{"internalType":"uint256","name":"","type":"uint256"}],"name":"ownerCollections","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},
+        {"inputs":[{"internalType":"bytes32","name":"salt","type":"bytes32"}],"name":"predictCollectionAddress","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},
+        {"inputs":[],"name":"renounceOwnership","outputs":[],"stateMutability":"nonpayable","type":"function"},
+        {"inputs":[{"internalType":"address","name":"_implementation","type":"address"}],"name":"setImplementation","outputs":[],"stateMutability":"nonpayable","type":"function"},
+        {"inputs":[{"internalType":"address","name":"newOwner","type":"address"}],"name":"transferOwnership","outputs":[],"stateMutability":"nonpayable","type":"function"}]
+    },
   },
   31337: {
     NFTLaunchpadKit: {
@@ -4315,6 +4340,31 @@ const deployedContracts = {
       }
 ]
       ,
+    },
+    NFTLaunchpadKitFactory: {
+      address: "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+      abi: [{"inputs":[{"internalType":"address","name":"_implementation","type":"address"},{"internalType":"address","name":"_owner","type":"address"}],"stateMutability":"nonpayable","type":"constructor"},
+        {"inputs":[],"name":"DeploymentFailed","type":"error"},
+        {"inputs":[],"name":"FailedDeployment","type":"error"},
+        {"inputs":[{"internalType":"uint256","name":"balance","type":"uint256"},{"internalType":"uint256","name":"needed","type":"uint256"}],"name":"InsufficientBalance","type":"error"},
+        {"inputs":[{"internalType":"address","name":"owner","type":"address"}],"name":"OwnableInvalidOwner","type":"error"},
+        {"inputs":[{"internalType":"address","name":"account","type":"address"}],"name":"OwnableUnauthorizedAccount","type":"error"},
+        {"inputs":[],"name":"ZeroAddress","type":"error"},
+        {"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"cloneAddress","type":"address"},{"indexed":true,"internalType":"address","name":"owner","type":"address"},{"indexed":false,"internalType":"string","name":"name","type":"string"},{"indexed":false,"internalType":"string","name":"symbol","type":"string"},{"indexed":false,"internalType":"uint256","name":"maxSupply","type":"uint256"}],"name":"CollectionCloned","type":"event"},
+        {"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"previousOwner","type":"address"},{"indexed":true,"internalType":"address","name":"newOwner","type":"address"}],"name":"OwnershipTransferred","type":"event"},
+        {"inputs":[{"internalType":"uint256","name":"","type":"uint256"}],"name":"allCollections","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},
+        {"inputs":[{"internalType":"string","name":"name_","type":"string"},{"internalType":"string","name":"symbol_","type":"string"},{"internalType":"uint256","name":"maxSupply","type":"uint256"},{"internalType":"uint256","name":"maxPerWallet","type":"uint256"},{"internalType":"uint256","name":"mintPrice","type":"uint256"}],"name":"deployCollection","outputs":[{"internalType":"address","name":"clone","type":"address"}],"stateMutability":"nonpayable","type":"function"},
+        {"inputs":[{"internalType":"bytes32","name":"salt","type":"bytes32"},{"internalType":"string","name":"name_","type":"string"},{"internalType":"string","name":"symbol_","type":"string"},{"internalType":"uint256","name":"maxSupply","type":"uint256"},{"internalType":"uint256","name":"maxPerWallet","type":"uint256"},{"internalType":"uint256","name":"mintPrice","type":"uint256"}],"name":"deployCollectionDeterministic","outputs":[{"internalType":"address","name":"clone","type":"address"}],"stateMutability":"nonpayable","type":"function"},
+        {"inputs":[{"internalType":"uint256","name":"offset","type":"uint256"},{"internalType":"uint256","name":"limit","type":"uint256"}],"name":"getAllCollections","outputs":[{"internalType":"address[]","name":"","type":"address[]"}],"stateMutability":"view","type":"function"},
+        {"inputs":[],"name":"getCollectionCount","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},
+        {"inputs":[{"internalType":"address","name":"_owner","type":"address"}],"name":"getCollectionsByOwner","outputs":[{"internalType":"address[]","name":"","type":"address[]"}],"stateMutability":"view","type":"function"},
+        {"inputs":[],"name":"implementation","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},
+        {"inputs":[],"name":"owner","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},
+        {"inputs":[{"internalType":"address","name":"","type":"address"},{"internalType":"uint256","name":"","type":"uint256"}],"name":"ownerCollections","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},
+        {"inputs":[{"internalType":"bytes32","name":"salt","type":"bytes32"}],"name":"predictCollectionAddress","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},
+        {"inputs":[],"name":"renounceOwnership","outputs":[],"stateMutability":"nonpayable","type":"function"},
+        {"inputs":[{"internalType":"address","name":"_implementation","type":"address"}],"name":"setImplementation","outputs":[],"stateMutability":"nonpayable","type":"function"},
+        {"inputs":[{"internalType":"address","name":"newOwner","type":"address"}],"name":"transferOwnership","outputs":[],"stateMutability":"nonpayable","type":"function"}]
     },
   },
 } as const;


### PR DESCRIPTION
Closes #34

## 轮子调研结论（先调研后动手，按你的要求）

| 候选 | 结论 |
|------|------|
| **thirdweb Dashboard** | 流程模式可借鉴（元数据 → 网络 → 部署 → 配置引导）→ **向导结构照它设计** |
| OpenZeppelin Contract Wizard | 表单→合约模式可借鉴，但它是离线生成代码，我们是链上部署 |
| Zora Create / Manifold Studio | 闭源，无 OSS 可复用 |
| ChainSafe NFT Launchpad | **已下线（404）** —— 又一个纯 launchpad 无网络效应死掉的案例 |
| sol-launchpad / gas-optimized-nft-launchpad | 20★ 级别，只有合约没有创作者 UI |
| **结论** | 没有现成适配我们 Factory-clone 栈的开源轮子 —— 模式借鉴 thirdweb，代码全新 |

## 改动内容

1. **API**：`POST /api/collections` 支持 `contractAddress` + `chainId`（校验 + 小写化，默认 11155111）
2. **契约配置**：`NFTLaunchpadKitFactory` 加入 deployedContracts（Sepolia 0x1e3200… + localhost 31337）
3. **前端向导**（admin 新增 🚀 创建集合 tab）：
   - ①基本信息（名称/符号/总量/价格/封面图 IPFS 上传）
   - ②链上部署（浏览器钱包签名，Factory clone ~371k gas）
   - ③平台注册（自动关联合约地址）
   - ④完成引导（一键跳转 Sale/Royalty/Whitelist）
   - 创建后自动切换到新集合
4. **测试**：+3 个 API 用例（77 总）

## 验证

- [x] `tsc --noEmit` 0 error
- [x] `vitest` **77/77**
- [x] `next build` EXIT 0（真实构建）

> 注：向导的核心链路（Factory 部署 → CollectionCloned 事件 → 注册）与 #35 的 agent 示例同构，后者已本地链实测通过。