### PR TITLE
[#36] AI 元数据管线：一键生成 1000 个 token 元数据并上传 IPFS

### DIFF
--- a/scaffold-alchemy-main/.env.example
+++ b/scaffold-alchemy-main/.env.example
@@ -32,3 +32,7 @@ SIGNER_PRIVATE_KEY=
 
 # Override the Sepolia RPC URL (defaults to Alchemy based on ALCHEMY_API_KEY)
 SEPOLIA_RPC_URL=
+
+# Pinata JWT for the AI metadata pipeline (/api/metadata/generate, v3 uploads API)
+# Get one at https://app.pinata.cloud/developers/api-keys
+PINATA_JWT=

--- a/scaffold-alchemy-main/packages/nextjs/__tests__/api/metadata.test.ts
+++ b/scaffold-alchemy-main/packages/nextjs/__tests__/api/metadata.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { POST } from "~~/app/api/metadata/generate/route";
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request("http://localhost/api/metadata/generate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-forwarded-for": "1.2.3.4" },
+    body: JSON.stringify(body),
+  }) as any;
+}
+
+describe("POST /api/metadata/generate", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects missing fields", async () => {
+    const res = await POST(makeRequest({ name: "A" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain("imageUrl");
+  });
+
+  it("rejects an invalid imageUrl scheme", async () => {
+    const res = await POST(makeRequest({ name: "A", imageUrl: "ftp://x", count: 1 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an invalid count", async () => {
+    const res = await POST(makeRequest({ name: "A", imageUrl: "https://x.png", count: 0 }));
+    expect(res.status).toBe(400);
+    const res2 = await POST(makeRequest({ name: "A", imageUrl: "https://x.png", count: 10001 }));
+    expect(res2.status).toBe(400);
+  });
+
+  it("dryRun returns a preview without uploading", async () => {
+    const res = await POST(
+      makeRequest({ name: "Agent Club", imageUrl: "https://cdn.example.com/{id}.png", count: 2, dryRun: true }),
+    );
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.dryRun).toBe(true);
+    expect(body.count).toBe(2);
+    expect(body.preview).toHaveLength(2);
+    expect(body.preview[0].name).toBe("Agent Club #0");
+    expect(body.baseUri).toBeUndefined();
+  });
+
+  it("returns a mock baseUri when PINATA_JWT is not configured", async () => {
+    delete process.env.PINATA_JWT;
+    const res = await POST(
+      makeRequest({ name: "Agent Club", imageUrl: "https://cdn.example.com/{id}.png", count: 5 }),
+    );
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.mock).toBe(true);
+    expect(body.baseUri).toMatch(/^ipfs:\/\/QmMock/);
+    expect(body.count).toBe(5);
+  });
+
+  it("uploads the folder and returns the real baseUri when PINATA_JWT is set", async () => {
+    process.env.PINATA_JWT = "test-jwt";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ data: { cid: "QmRealFolder" } }),
+      }),
+    );
+
+    const res = await POST(
+      makeRequest({ name: "Agent Club", imageUrl: "https://cdn.example.com/{id}.png", count: 3 }),
+    );
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.baseUri).toBe("ipfs://QmRealFolder/");
+    expect(body.mock).toBeUndefined();
+
+    // One upload call for the whole folder (the "5 minutes for 1000 tokens" promise).
+    const fetchMock = vi.mocked(fetch);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    delete process.env.PINATA_JWT;
+  });
+
+  it("surfaces Pinata errors", async () => {
+    process.env.PINATA_JWT = "test-jwt";
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, text: () => Promise.resolve("boom") }));
+
+    const res = await POST(
+      makeRequest({ name: "A", imageUrl: "https://x.png", count: 1 }),
+    );
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toContain("Pinata v3 error");
+    delete process.env.PINATA_JWT;
+  });
+});

--- a/scaffold-alchemy-main/packages/nextjs/__tests__/lib/metadata.test.ts
+++ b/scaffold-alchemy-main/packages/nextjs/__tests__/lib/metadata.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import { generateMetadata, buildMetadataFormData, pinMetadataFolder } from "~~/utils/metadata";
+
+describe("generateMetadata", () => {
+  it("generates one token per count with sequential names", () => {
+    const tokens = generateMetadata({ name: "Agent Club", imageUrl: "https://cdn.example.com/a/{id}.png", count: 3 });
+    expect(tokens).toHaveLength(3);
+    expect(tokens[0].name).toBe("Agent Club #0");
+    expect(tokens[1].name).toBe("Agent Club #1");
+    expect(tokens[2].name).toBe("Agent Club #2");
+  });
+
+  it("replaces the {id} placeholder in the image URL", () => {
+    const tokens = generateMetadata({ name: "A", imageUrl: "https://cdn.example.com/a/{id}.png", count: 2 });
+    expect(tokens[0].image).toBe("https://cdn.example.com/a/0.png");
+    expect(tokens[1].image).toBe("https://cdn.example.com/a/1.png");
+  });
+
+  it("uses the same image when no placeholder is present", () => {
+    const tokens = generateMetadata({ name: "A", imageUrl: "ipfs://QmSame/art.png", count: 2 });
+    expect(tokens[0].image).toBe("ipfs://QmSame/art.png");
+    expect(tokens[1].image).toBe("ipfs://QmSame/art.png");
+  });
+
+  it("attaches shared attributes and description", () => {
+    const tokens = generateMetadata({
+      name: "A",
+      imageUrl: "x.png",
+      count: 1,
+      description: "AI generated",
+      attributes: [{ trait_type: "Tier", value: "Gold" }],
+    });
+    expect(tokens[0].description).toBe("AI generated");
+    expect(tokens[0].attributes).toEqual([{ trait_type: "Tier", value: "Gold" }]);
+  });
+
+  it("is deterministic for the same input", () => {
+    const input = { name: "A", imageUrl: "x/{id}.png", count: 5 };
+    expect(generateMetadata(input)).toEqual(generateMetadata(input));
+  });
+
+  it("supports 10000 tokens (the pipeline ceiling)", () => {
+    const tokens = generateMetadata({ name: "Big", imageUrl: "x/{id}.png", count: 10000 });
+    expect(tokens).toHaveLength(10000);
+    expect(tokens[9999].name).toBe("Big #9999");
+  });
+});
+
+describe("buildMetadataFormData", () => {
+  it("appends one file part per token named <id>.json", () => {
+    const tokens = generateMetadata({ name: "A", imageUrl: "x.png", count: 2 });
+    const fd = buildMetadataFormData(tokens, "A");
+    const files = fd.getAll("file");
+    expect(files).toHaveLength(2);
+    expect(fd.get("wrap_with_directory")).toBe("true");
+    expect(fd.get("name")).toBe("A");
+  });
+});
+
+describe("pinMetadataFolder", () => {
+  it("parses the CID from the Pinata v3 response", async () => {
+    const fakeFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { cid: "QmFolderCid" } }),
+    });
+    vi.stubGlobal("fetch", fakeFetch);
+
+    const tokens = generateMetadata({ name: "A", imageUrl: "x.png", count: 1 });
+    const { baseUri } = await pinMetadataFolder(tokens, "A", "jwt-123");
+    expect(baseUri).toBe("ipfs://QmFolderCid/");
+
+    // The request must be multipart with the JWT auth header.
+    const [url, init] = fakeFetch.mock.calls[0];
+    expect(url).toBe("https://uploads.pinata.cloud/v3/files");
+    expect(init.headers.Authorization).toBe("Bearer jwt-123");
+    expect(init.body).toBeInstanceOf(FormData);
+    vi.unstubAllGlobals();
+  });
+
+  it("throws a readable error when Pinata rejects", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, text: () => Promise.resolve("rate limited") }),
+    );
+    const tokens = generateMetadata({ name: "A", imageUrl: "x.png", count: 1 });
+    await expect(pinMetadataFolder(tokens, "A", "jwt")).rejects.toThrow(/Pinata v3 error: rate limited/);
+    vi.unstubAllGlobals();
+  });
+});

--- a/scaffold-alchemy-main/packages/nextjs/app/api/collections/route.ts
+++ b/scaffold-alchemy-main/packages/nextjs/app/api/collections/route.ts
@@ -84,6 +84,7 @@ export async function POST(req: NextRequest) {
     coverImage,
     contractAddress,
     chainId,
+    baseURI,
   } = body;
 
   if (!name || !symbol || !maxSupply || !mintPrice || !ownerAddress) {
@@ -112,6 +113,7 @@ export async function POST(req: NextRequest) {
       coverImage,
       contractAddress: contractAddress ? contractAddress.toLowerCase() : null,
       chainId: chainId || 11155111,
+      baseURI: baseURI || null,
       ownerId: user.id,
     },
   });

--- a/scaffold-alchemy-main/packages/nextjs/app/api/metadata/generate/route.ts
+++ b/scaffold-alchemy-main/packages/nextjs/app/api/metadata/generate/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { RATE_LIMITS, checkRateLimit, getClientIp } from "~~/lib/rateLimit";
+import { generateMetadata, pinMetadataFolder } from "~~/utils/metadata";
+
+/**
+ * POST /api/metadata/generate — AI metadata pipeline (#36)
+ *
+ * Body: {
+ *   name: string,            // collection name
+ *   description?: string,    // shared description
+ *   imageUrl: string,        // image URL, supports {id} placeholder
+ *   count: number,           // 1..10000 tokens
+ *   attributes?: { trait_type, value }[],
+ *   dryRun?: boolean         // generate only, no upload (returns preview)
+ * }
+ *
+ * Returns: { baseUri: string, count: number, mock?: boolean, dryRun?: boolean, preview?: [...] }
+ *
+ * Upload strategy: one Pinata v3 request pins the whole folder
+ * (wrap_with_directory), so 1000 tokens upload in seconds.
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const ip = getClientIp(req);
+    const rl = checkRateLimit(`meta:${ip}`, RATE_LIMITS.normal);
+    if (!rl.success) {
+      return NextResponse.json(
+        { error: "Rate limit exceeded. Try again later." },
+        { status: 429, headers: { "Retry-After": String(rl.retryAfter) } },
+      );
+    }
+
+    const body = await req.json();
+    const { name, description, imageUrl, count, attributes, dryRun } = body;
+
+    if (!name || typeof name !== "string") {
+      return NextResponse.json({ error: "Name required" }, { status: 400 });
+    }
+    if (!imageUrl || typeof imageUrl !== "string") {
+      return NextResponse.json({ error: "imageUrl required" }, { status: 400 });
+    }
+    if (!/^(https?:\/\/|ipfs:\/\/)/.test(imageUrl)) {
+      return NextResponse.json({ error: "imageUrl must be http(s) or ipfs://" }, { status: 400 });
+    }
+    const n = Number(count);
+    if (!Number.isInteger(n) || n < 1 || n > 10000) {
+      return NextResponse.json({ error: "count must be an integer 1..10000" }, { status: 400 });
+    }
+    if (attributes && !Array.isArray(attributes)) {
+      return NextResponse.json({ error: "attributes must be an array" }, { status: 400 });
+    }
+
+    const tokens = generateMetadata({
+      name: String(name).trim(),
+      description: description ? String(description) : undefined,
+      imageUrl: String(imageUrl),
+      count: n,
+      attributes,
+    });
+
+    if (dryRun) {
+      return NextResponse.json({
+        count: tokens.length,
+        dryRun: true,
+        preview: tokens.slice(0, 3),
+      });
+    }
+
+    // Real upload path — Pinata v3 (JWT). Without keys we return a mock CID
+    // so the flow is testable in dev (same pattern as /api/ipfs).
+    const jwt = process.env.PINATA_JWT;
+    if (!jwt) {
+      const mockCid = `QmMock${Date.now().toString(36)}`;
+      return NextResponse.json({
+        baseUri: `ipfs://${mockCid}/`,
+        count: tokens.length,
+        mock: true,
+      });
+    }
+
+    const { baseUri } = await pinMetadataFolder(tokens, String(name).trim(), jwt);
+    return NextResponse.json({ baseUri, count: tokens.length });
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || "Internal error" }, { status: 500 });
+  }
+}

--- a/scaffold-alchemy-main/packages/nextjs/components/CreateCollection.tsx
+++ b/scaffold-alchemy-main/packages/nextjs/components/CreateCollection.tsx
@@ -43,6 +43,13 @@ export default function CreateCollection({ onCreated }: CreateCollectionProps) {
   const [cloneAddress, setCloneAddress] = useState<string | null>(null);
   const [collectionId, setCollectionId] = useState<string | null>(null);
 
+  // AI metadata pipeline (#36)
+  const [metaOpen, setMetaOpen] = useState(false);
+  const [metaImageUrl, setMetaImageUrl] = useState("");
+  const [metaCount, setMetaCount] = useState("100");
+  const [metaBusy, setMetaBusy] = useState(false);
+  const [baseUri, setBaseUri] = useState("");
+
   const { writeContractAsync, isPending: isDeploying } = useWriteContract();
   const [deployTxHash, setDeployTxHash] = useState<`0x${string}` | null>(null);
   const { data: deployReceipt, isError: deployFailed } = useWaitForTransactionReceipt({
@@ -117,6 +124,33 @@ export default function CreateCollection({ onCreated }: CreateCollectionProps) {
     }
   }
 
+  /** AI metadata pipeline (#36): generate N metadata files and pin the folder to IPFS. */
+  async function handleGenerateMetadata() {
+    if (!metaImageUrl.trim()) return;
+    setMetaBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/metadata/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim() || "Collection",
+          imageUrl: metaImageUrl.trim(),
+          count: Number(metaCount) || 100,
+          description: description.trim() || undefined,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "生成失败");
+      if (data.baseUri) setBaseUri(data.baseUri);
+      setError(data.mock ? "（开发模式）未配置 PINATA_JWT，返回了模拟 CID —— 配置后即为真实 IPFS 地址" : null);
+    } catch (e: any) {
+      setError(e.message || "元数据生成失败");
+    } finally {
+      setMetaBusy(false);
+    }
+  }
+
   async function handleDeploy() {
     setError(null);
     if (!address || !factory) return;
@@ -151,6 +185,7 @@ export default function CreateCollection({ onCreated }: CreateCollectionProps) {
           coverImage: coverImage || undefined,
           contractAddress: cloneAddress,
           chainId,
+          baseURI: baseUri || undefined,
         }),
       });
       const data = await res.json();
@@ -254,6 +289,52 @@ export default function CreateCollection({ onCreated }: CreateCollectionProps) {
               <span className="label-text">描述（可选）</span>
               <textarea className="textarea textarea-bordered" value={description} onChange={e => setDescription(e.target.value)} rows={2} />
             </label>
+
+            {/* AI metadata pipeline (#36) — generate + pin the whole folder in one click */}
+            <div className="border border-base-300 rounded-xl">
+              <button
+                type="button"
+                className="w-full flex items-center justify-between px-4 py-3 text-sm font-semibold"
+                onClick={() => setMetaOpen(o => !o)}
+              >
+                <span>⚡ AI 元数据生成（可选）</span>
+                <span className="text-base-content/40">{metaOpen ? "▾" : "▸"}</span>
+              </button>
+              {metaOpen && (
+                <div className="px-4 pb-4 space-y-3">
+                  <div className="text-xs text-base-content/50">
+                    输入图片 URL（支持 <code>{`{id}`}</code> 占位符）和数量，一键生成 {`{id}.json`} 元数据并打包上传 IPFS，产出可直接用作 Base URI 的地址。
+                  </div>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                    <input
+                      className="input input-bordered input-sm"
+                      value={metaImageUrl}
+                      onChange={e => setMetaImageUrl(e.target.value)}
+                      placeholder="https://cdn.example.com/agents/{id}.png"
+                    />
+                    <input
+                      type="number"
+                      min={1}
+                      max={10000}
+                      className="input input-bordered input-sm"
+                      value={metaCount}
+                      onChange={e => setMetaCount(e.target.value)}
+                      placeholder="数量（1-10000）"
+                    />
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button className="btn btn-sm btn-outline" onClick={handleGenerateMetadata} disabled={metaBusy || !metaImageUrl.trim()}>
+                      {metaBusy ? "生成中…" : "🚀 生成并上传"}
+                    </button>
+                    {baseUri && (
+                      <div className="text-xs text-success break-all flex-1">
+                        Base URI: <code>{baseUri}</code>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
             <div className="flex justify-end gap-2">
               <button className="btn btn-primary" disabled={!isValid} onClick={() => setStep(1)}>
                 下一步：链上部署 →

--- a/scaffold-alchemy-main/packages/nextjs/utils/metadata.ts
+++ b/scaffold-alchemy-main/packages/nextjs/utils/metadata.ts
@@ -1,0 +1,83 @@
+/**
+ * AI metadata pipeline utilities (#36).
+ *
+ * Generates ERC-721 metadata JSON for a whole collection and pins the
+ * folder to IPFS in ONE request (Pinata v3 uploads API, wrap_with_directory),
+ * returning a single base URI: ipfs://<folder-cid>/0.json … ipfs://<folder-cid>/N.json
+ */
+
+export interface MetadataAttributes {
+  trait_type: string;
+  value: string;
+}
+
+export interface MetadataGenerationInput {
+  /** Collection name — each token is named "<name> #<id>". */
+  name: string;
+  /** Shared description for every token. */
+  description?: string;
+  /**
+   * Token image. Supports the `{id}` placeholder, e.g.
+   * "https://cdn.example.com/agents/{id}.png" — replaced per token.
+   */
+  imageUrl: string;
+  /** Number of tokens to generate (1..10000). */
+  count: number;
+  /** Attributes shared by every token (AI-style traits). */
+  attributes?: MetadataAttributes[];
+}
+
+export interface GeneratedToken {
+  name: string;
+  description: string;
+  image: string;
+  attributes: MetadataAttributes[];
+}
+
+/** Generate deterministic metadata for every token of a collection. */
+export function generateMetadata(input: MetadataGenerationInput): GeneratedToken[] {
+  const { name, description = "", imageUrl, count, attributes = [] } = input;
+  const tokens: GeneratedToken[] = [];
+  for (let i = 0; i < count; i++) {
+    tokens.push({
+      name: `${name} #${i}`,
+      description,
+      image: imageUrl.includes("{id}") ? imageUrl.replaceAll("{id}", String(i)) : imageUrl,
+      attributes: [...attributes],
+    });
+  }
+  return tokens;
+}
+
+/** Build the multipart form for Pinata v3: one file part per token, wrapped in a directory. */
+export function buildMetadataFormData(tokens: GeneratedToken[], folderName: string): FormData {
+  const fd = new FormData();
+  tokens.forEach((token, i) => {
+    fd.append("file", new File([JSON.stringify(token)], `${i}.json`, { type: "application/json" }));
+  });
+  fd.append("name", folderName);
+  fd.append("wrap_with_directory", "true");
+  return fd;
+}
+
+/** Upload the whole metadata folder in one request; returns ipfs://<cid>/. */
+export async function pinMetadataFolder(
+  tokens: GeneratedToken[],
+  folderName: string,
+  jwt: string,
+): Promise<{ baseUri: string }> {
+  const fd = buildMetadataFormData(tokens, folderName);
+  const res = await fetch("https://uploads.pinata.cloud/v3/files", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${jwt}` },
+    body: fd,
+  });
+  if (!res.ok) {
+    const err = await res.text();
+    throw new Error(`Pinata v3 error: ${err.slice(0, 300)}`);
+  }
+  const data = await res.json();
+  const cid = data?.data?.cid ?? data?.cid;
+  if (!cid) throw new Error("Pinata response is missing a CID");
+  return { baseUri: `ipfs://${cid}/` };
+}


### PR DESCRIPTION
Closes #36

## 交付内容

**"AI 生图 → IPFS → 集合 Base URI" 闭环的一半**（生成+上传侧），并集成进 #34 的创建向导：

1. **`utils/metadata.ts`**：确定性元数据生成（`名字 #id`、`{id}` 图片占位符、共享 attributes）+ **Pinata v3 目录上传**（`wrap_with_directory`）—— **一个请求打包整个文件夹**，返回 `ipfs://<cid>/` 直接作为合约 Base URI
2. **`POST /api/metadata/generate`**：校验（count 1-10000、http(s)/ipfs 图源）、`dryRun` 预览模式、无 key 时 mock CID（与 /api/ipfs 同模式）、配 `PINATA_JWT` 后真实上传
3. **创建向导集成**：step 1 新增可折叠"⚡ AI 元数据生成"区块 → 生成+上传 → 显示 Base URI → 注册集合时持久化（POST /api/collections 新增 baseURI 字段，模型本来就有）
4. `.env.example` 补 `PINATA_JWT`

## 性能承诺

**1000 个 token = 1 个上传请求（秒级）**，而不是 1000 次 API 调用 —— 满足验收"5 分钟生成 1000 个"。

## 验证

- [x] `tsc --noEmit` 0 error
- [x] `vitest` **93/93**（+16：生成逻辑确定性/占位符/10000 上限 + 路由校验/dryRun/mock/真实上传（fetch mock）/错误透传）
- [x] `next build` EXIT 0
- [x] `next lint` exit 0

## 下一步（串成完整闭环）

- #35（agent 示例）+ #34（创建向导）+ #36（元数据管线）= **"agent 从零发一个集合"** 的完整 demo
- #40（agent 身份 API）补产品层