### PR TITLE
[#37] Base Sepolia 多链部署支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,25 @@ yarn workspace @scaffold-alchemy/nextjs test
 - `develop`：日常开发主线，feature 分支从这里拉出、PR 合入这里
 - 详细规范见 `scaffold-alchemy-main/CONTRIBUTING.md`
 
+## 多链部署（#37）
+
+支持 Sepolia（默认）与 **Base Sepolia**：
+
+```bash
+cd scaffold-alchemy-main
+
+# Sepolia（默认）
+yarn deploy:final                       # 或 npx hardhat deploy --network sepolia
+
+# Base Sepolia —— agent 经济的主场
+yarn deploy:base                        # npx hardhat deploy --network baseSepolia
+yarn verify:base                        # Etherscan/Basescan 验证（需 BASESCAN_API_KEY）
+```
+
+- 环境变量：`SEPOLIA_RPC_URL` / `BASE_SEPOLIA_RPC_URL`（缺省走 Alchemy）、`ETHERSCAN_API_KEY` / `BASESCAN_API_KEY`、`PRIVATE_KEY`
+- 部署后把合约地址写入 `packages/nextjs/contracts/deployedContracts.ts` 对应 chainId（84532 条目已预置）
+- 前端 `scaffold.config.ts` 已配置双网络（`targetNetworks[0]` = Sepolia 为主链）
+
 ## 项目结构
 
 ```

--- a/scaffold-alchemy-main/.env.example
+++ b/scaffold-alchemy-main/.env.example
@@ -36,3 +36,7 @@ SEPOLIA_RPC_URL=
 # Pinata JWT for the AI metadata pipeline (/api/metadata/generate, v3 uploads API)
 # Get one at https://app.pinata.cloud/developers/api-keys
 PINATA_JWT=
+
+# Base Sepolia (#37) — deploy target for the agent economy chain
+BASE_SEPOLIA_RPC_URL=
+BASESCAN_API_KEY=

--- a/scaffold-alchemy-main/package.json
+++ b/scaffold-alchemy-main/package.json
@@ -46,7 +46,9 @@
     "test": "yarn hardhat:test",
     "vercel": "yarn workspace @scaffold-alchemy/nextjs vercel",
     "vercel:yolo": "yarn workspace @scaffold-alchemy/nextjs vercel:yolo",
-    "verify": "yarn hardhat:verify"
+    "verify": "yarn hardhat:verify",
+    "deploy:base": "yarn workspace @scaffold-alchemy/hardhat deploy --network baseSepolia",
+    "verify:base": "yarn workspace @scaffold-alchemy/hardhat hardhat-verify --network baseSepolia"
   },
   "packageManager": "yarn@3.2.3",
   "devDependencies": {

--- a/scaffold-alchemy-main/packages/hardhat/hardhat.config.ts
+++ b/scaffold-alchemy-main/packages/hardhat/hardhat.config.ts
@@ -21,6 +21,10 @@ const sepoliaRpcUrl = process.env.SEPOLIA_RPC_URL
   || alchemyRpcUrl
   || (alchemyApiKey ? `https://eth-sepolia.g.alchemy.com/v2/${alchemyApiKey}` : "");
 
+// Base Sepolia (#37) — agent economy's home turf; Alchemy supports it by default.
+const baseSepoliaRpcUrl = process.env.BASE_SEPOLIA_RPC_URL
+  || (alchemyApiKey ? `https://base-sepolia.g.alchemy.com/v2/${alchemyApiKey}` : "");
+
 if (!privateKey) {
   console.warn("PRIVATE_KEY not found in .env file. Deploy to testnet will not work.");
 }
@@ -56,10 +60,16 @@ const config: HardhatUserConfig = {
       accounts: privateKey ? [privateKey] : [],
       chainId: 11155111,
     },
+    baseSepolia: {
+      url: baseSepoliaRpcUrl,
+      accounts: privateKey ? [privateKey] : [],
+      chainId: 84532,
+    },
   },
   etherscan: {
     apiKey: {
       sepolia: etherscanApiKey || "",
+      baseSepolia: process.env.BASESCAN_API_KEY || "",
     },
   },
   gasReporter: {

--- a/scaffold-alchemy-main/packages/nextjs/contracts/deployedContracts.ts
+++ b/scaffold-alchemy-main/packages/nextjs/contracts/deployedContracts.ts
@@ -4367,6 +4367,10 @@ const deployedContracts = {
         {"inputs":[{"internalType":"address","name":"newOwner","type":"address"}],"name":"transferOwnership","outputs":[],"stateMutability":"nonpayable","type":"function"}]
     },
   },
+  84532: {
+    // Base Sepolia (#37) — addresses are written here after the first deploy:
+    //   yarn workspace @scaffold-alchemy/hardhat deploy --network baseSepolia
+  },
 } as const;
 
 export default deployedContracts satisfies GenericContractsDeclaration;

--- a/scaffold-alchemy-main/packages/nextjs/scaffold.config.ts
+++ b/scaffold-alchemy-main/packages/nextjs/scaffold.config.ts
@@ -17,8 +17,8 @@ export type ScaffoldConfig = {
 };
 
 const scaffoldConfig = {
-  // The networks on which your DApp is live
-  targetNetworks: [chain],
+  // The networks on which your DApp is live (#37 — multi-chain: Sepolia primary + Base Sepolia)
+  targetNetworks: [chain, chains.baseSepolia],
 
   // The interval at which your front-end polls the RPC servers for new data
   // it has no effect if you only target the local network (default is 4000)


### PR DESCRIPTION
Closes #37

## 改动内容

1. **hardhat.config.ts**：`baseSepolia` 网络（84532，RPC 走 `BASE_SEPOLIA_RPC_URL` 或 Alchemy）+ `basescan` 验证 key
2. **scaffold.config.ts**：`targetNetworks = [sepolia, baseSepolia]` —— 主链仍是 Sepolia（所有 `targetNetworks[0]` 消费方不受影响），Base 作为第二网络就绪
3. **deployedContracts.ts**：预置 84532 空条目（首次部署后填入地址）；未部署前前端优雅降级（向导显示"未配置 Factory"）
4. **package.json**：`deploy:base` / `verify:base` 一条命令部署+验证
5. **.env.example + README**：Base 环境变量与多链部署章节

## 验证

- [x] `hardhat run --network baseSepolia` 配置加载正确（chainId 84532，无 RPC 也正常）
- [x] 合约 100/100 测试通过
- [x] `tsc --noEmit` 0 error（清缓存全量）
- [x] 前端 93/93 + `next build` EXIT 0
- [x] CI 待跑

## 备注（类型债）

scaffold 的 hook 泛型对 `chain` 类型极其敏感：原配置靠 `Object.values()` 推断为 `any` 才编译过（`ConfiguredChainId` 泛型从未被严格检查）。我尝试收紧类型会破坏它的推导（union-of-chain-ids → never），因此**保留了原 any 语义**，记录为 scaffold 层类型债，后续单独处理。

## 下一步

配好 `PRIVATE_KEY` + `ALCHEMY_API_KEY`（+ `BASESCAN_API_KEY`）后：`yarn deploy:base` 一键部署 → 地址填入 84532 条目 → 前端即可切换 Base 网络铸造（与 #15 的部署验证同批做）。