### PR TITLE
[#38] 英文文档 + 3 篇教程 + 部署流水线网络选择

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,15 +1,24 @@
-name: Deploy to Sepolia
+name: Deploy Contracts
 
-# Manual trigger only. Secrets live in the `sepolia` GitHub environment —
+# Manual trigger only. Secrets live in GitHub environments —
 # no local .env required, no real keys anywhere in the repo.
 on:
   workflow_dispatch:
+    inputs:
+      network:
+        description: "Target network"
+        required: true
+        default: "sepolia"
+        type: choice
+        options:
+          - sepolia
+          - baseSepolia
 
 jobs:
   deploy:
-    name: Deploy Contracts
+    name: Deploy to ${{ github.event.inputs.network }}
     runs-on: ubuntu-latest
-    environment: sepolia
+    environment: ${{ github.event.inputs.network }}
     steps:
       - uses: actions/checkout@v4
 
@@ -30,10 +39,11 @@ jobs:
         run: yarn hardhat:compile
         working-directory: scaffold-alchemy-main
 
-      - name: Deploy to Sepolia
-        run: yarn deploy:final
+      - name: Deploy contracts
+        run: yarn workspace @scaffold-alchemy/hardhat deploy --network ${{ github.event.inputs.network }}
         working-directory: scaffold-alchemy-main
         env:
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+          BASESCAN_API_KEY: ${{ secrets.BASESCAN_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -1,147 +1,127 @@
-# NFT Launchpad Kit
+# NFT Launchpad Kit — Agent-Native Issuance Infrastructure
 
-一站式 NFT 发行平台：6 种铸造模式 + Factory Clone + 管理后台，Solidity + Next.js。
+> **The agent issues. The user mints.**
+> Give any AI agent a key and it can create collections, sign mint grants,
+> and issue on-chain assets (memberships, rewards, credentials, NFTs) —
+> fully automated, fully verifiable.
 
-## 功能
+Solidity (Hardhat) + Next.js 14 monorepo. 6 mint modes + Factory Clone + no-code
+creator wizard + AI metadata pipeline + admin dashboard + The Graph subgraph.
 
-**铸造模式：**
-- 公开铸造（固定价格 + 每钱包限制）
-- 白名单铸造（Merkle Proof 验证）
-- 荷兰拍卖（价格随时间递减）
-- 签名授权铸造（传统 + EIP-712 结构化签名）
-- ERC20 代币支付铸造
-- Phased Claim Conditions（多阶段分发，支持 Merkle 白名单）
+---
 
-**合约特性：**
-- ERC721A 批量铸造（70-90% gas 节省）
-- ERC-1167 Minimal Proxy Clone（93% 部署 gas 节省）
-- ERC-2981 版税标准
-- EIP-712 域分隔 + nonce 防重放
-- SafeERC20（兼容 USDT 等非标准代币）
-- ReentrancyGuard + Pausable + AccessControl
-- 33 个自定义错误（零字符串 require）
-- 37 个事件（支持链下索引）
-- Feistel 密码链上 tokenURI 洗牌
+## Why this exists
 
-**前端：**
-- Next.js + viem + scaffold-alchemy
-- 管理后台（仪表盘 + 事件日志 + 8 个管理面板）
-- 白名单管理器（CSV 上传 → Merkle Root 生成）
-- 实时铸造活动流 + 交易状态 + Gas 估算
+Classic launchpads mint NFTs for humans. This kit's contracts contain a
+primitive that works for **programs**: the trusted-signer flow
+(`mintWithSignature712V2`) — an off-chain signature from a registered address
+authorizes an on-chain mint, one-time (UID), expiring (deadline), scoped
+(quantity, price). The "signer" doesn't have to be a person.
 
-## 快速开始
+**An AI agent holding a key can issue assets on demand**: quest rewards after
+a webhook fires, membership cards per purchase, gated access by deadline,
+credentials with per-signature pricing. The on-chain half is tamper-evident;
+the off-chain half is auditable via the agent registry.
 
-```bash
-# 安装依赖（yarn 3，含 prisma generate）
-cd scaffold-alchemy-main
-yarn install
+## Features
 
-# 合约测试
-yarn hardhat:test          # 96 个合约测试
+**Mint modes**
 
-# 前端（vitest / 类型检查 / lint）
-yarn workspace @scaffold-alchemy/nextjs test          # 74 个前端测试
-yarn workspace @scaffold-alchemy/nextjs check-types   # 类型检查
-yarn workspace @scaffold-alchemy/nextjs dev           # 本地开发（端口 56900）
-```
+- Public mint (fixed price + per-wallet limit)
+- Allowlist mint (Merkle proof)
+- Dutch auction (linearly decreasing price)
+- Signature mint (legacy + EIP-712, UID-based V2 with per-grant pricing)
+- ERC20 payment mint
+- Phased Claim Conditions (N-phase drops, per-phase price/supply/allowlist)
 
-环境变量：复制根目录 `.env.example` 为 `.env` 并填写（Alchemy API Key 等）。
-开发流程、分支/PR 规范见 `scaffold-alchemy-main/CONTRIBUTING.md`。
+**Contract engineering**
 
-## 测试
+- ERC721A batch mint (70–90% gas savings)
+- ERC-1167 minimal-proxy Clone (93% cheaper deploys via Factory)
+- EIP-2981 royalties · EIP-712 domain separation · nonce + UID replay protection
+- SafeERC20 · ReentrancyGuard · Pausable · AccessControl
+- 28 custom errors (zero string requires) · 37 events (indexing-ready)
+- Feistel-based **bijective** tokenURI shuffle (cycle-walking, no collisions)
 
-```bash
-cd scaffold-alchemy-main
+**Product layer (M4)**
 
-# 运行全部 96 个合约测试（本地附带 gas 报告；CI 中关闭以提速）
-yarn hardhat:test
+- 🚀 **No-code creator wizard** — deploy a collection via the Factory in 4 steps
+- ⚡ **AI metadata pipeline** — generate + pin 1000 token metadata files in ONE
+  IPFS request (`ipfs://<cid>/` as Base URI)
+- 🤖 **Agent identity registry** — agents register, every issuance is audited
+  (`Agent` + `AgentGrant` records wired into `/api/signature`)
+- Admin dashboard (8 panels + analytics) · Whitelist manager (CSV → Merkle root)
+- Real-time mint feed · tx status · gas estimates
 
-# 前端：74 个 Vitest 用例
-yarn workspace @scaffold-alchemy/nextjs test
-```
-
-## CI（GitHub Actions）
-
-- `ci.yml`：PR 触发 —— 合约测试 + 前端类型/测试/lint 并行，约 3-4 分钟
-- `build.yml`：合并到 main/develop 后真实 `next build`
-- `deploy.yml`：手动触发 Sepolia 部署（GitHub Secrets）
-
-## 分支模型
-
-- `main`：只做发布（develop → main 的 release PR，合并后打 tag）
-- `develop`：日常开发主线，feature 分支从这里拉出、PR 合入这里
-- 详细规范见 `scaffold-alchemy-main/CONTRIBUTING.md`
-
-## 多链部署（#37）
-
-支持 Sepolia（默认）与 **Base Sepolia**：
+## Quick start
 
 ```bash
 cd scaffold-alchemy-main
+yarn install            # yarn 3; runs prisma generate automatically
 
-# Sepolia（默认）
-yarn deploy:final                       # 或 npx hardhat deploy --network sepolia
-
-# Base Sepolia —— agent 经济的主场
-yarn deploy:base                        # npx hardhat deploy --network baseSepolia
-yarn verify:base                        # Etherscan/Basescan 验证（需 BASESCAN_API_KEY）
+yarn hardhat:test       # 100 contract tests
+yarn workspace @scaffold-alchemy/nextjs test          # 104 frontend tests
+yarn workspace @scaffold-alchemy/nextjs check-types   # typecheck
+yarn workspace @scaffold-alchemy/nextjs dev           # dev server :56900
 ```
 
-- 环境变量：`SEPOLIA_RPC_URL` / `BASE_SEPOLIA_RPC_URL`（缺省走 Alchemy）、`ETHERSCAN_API_KEY` / `BASESCAN_API_KEY`、`PRIVATE_KEY`
-- 部署后把合约地址写入 `packages/nextjs/contracts/deployedContracts.ts` 对应 chainId（84532 条目已预置）
-- 前端 `scaffold.config.ts` 已配置双网络（`targetNetworks[0]` = Sepolia 为主链）
+Environment: copy `.env.example` to `.env` and fill in keys. Never commit
+secrets — env vars and GitHub Secrets only.
 
-## 项目结构
+## Tutorials (30-minute path: "my agent issues a collection")
 
+| Tutorial | What you'll do |
+|----------|----------------|
+| [Create a collection, no code](docs/tutorial-create-collection.md) | Run the wizard: deploy via Factory + register + publish |
+| [Agent-native minting](docs/tutorial-agent-minting.md) | An agent creates a collection and signs mint grants — runnable example in [`examples/agent`](scaffold-alchemy-main/examples/agent) |
+| [Deploy to Sepolia & Base](docs/tutorial-multichain.md) | One command per network, verify on Etherscan/Basescan |
+
+## Tests
+
+| Suite | Count | Command |
+|-------|-------|---------|
+| Contracts (Hardhat) | 100 | `yarn hardhat:test` |
+| Frontend (Vitest) | 104 | `yarn workspace @scaffold-alchemy/nextjs test` |
+
+Gas baselines: [`GAS_BASELINE.md`](scaffold-alchemy-main/GAS_BASELINE.md) ·
+Frontend baselines: [`TEST_BASELINE.md`](scaffold-alchemy-main/TEST_BASELINE.md)
+
+## CI (GitHub Actions)
+
+- `ci.yml` — PRs: contract tests + frontend type/test/lint in parallel, **~3–4 min**
+- `build.yml` — real `next build` on every merge to main/develop
+- `deploy.yml` — manual Sepolia/Base deploys with GitHub Secrets
+
+## Branch model
+
+- `main` — releases only (develop → main PR, tagged)
+- `develop` — day-to-day integration; feature branches PR into it
+- See `scaffold-alchemy-main/CONTRIBUTING.md`
+
+## Multi-chain
+
+Sepolia (default) and **Base Sepolia** supported:
+
+```bash
+yarn deploy:final      # Sepolia
+yarn deploy:base       # Base Sepolia — the agent economy's home
 ```
-scaffold-alchemy-main/       # Yarn 3 工作区
-├── packages/
-│   ├── hardhat/             # 智能合约
-│   │   ├── contracts/
-│   │   │   ├── NFTLaunchpadKit.sol        # 主合约（~1200 行，96 测试）
-│   │   │   └── NFTLaunchpadKitFactory.sol # Clone 工厂
-│   │   ├── test/            # 测试（96 个）
-│   │   └── deploy/          # 部署脚本
-│   ├── nextjs/              # 前端（74 个测试）
-│   │   ├── components/      # UI 组件
-│   │   ├── app/             # 页面路由 + API
-│   │   └── utils/           # 工具库（Merkle、签名、错误映射）
-│   └── subgraph/            # The Graph 子图
-└── GAS_BASELINE.md          # Gas 回归基准
-└── TEST_BASELINE.md         # 前端测试基线
-```
 
-## 技术栈
+## Security
 
-| 层 | 技术 |
-|---|------|
-| 合约 | Solidity 0.8.20 · ERC721A · OpenZeppelin · viaIR |
-| 前端 | Next.js 14 · viem · wagmi · TailwindCSS |
-| 测试 | Hardhat · Chai · hardhat-gas-reporter |
-| 部署 | hardhat-deploy · Sepolia 测试网 |
+ReentrancyGuard on every payable path · CEI ordering · excess-ETH refunds ·
+signature nonce/UID replay protection · zero-address checks · clone
+initialization guards · Slither-reviewed · bijective reveal shuffle.
+> Mainnet deployment requires a professional audit (see `PROJECT.md`).
 
-## 安全机制
+## Tech stack
 
-- ReentrancyGuard（所有 payable + withdraw 函数）
-- Pausable（紧急暂停所有铸造）
-- AccessControl（角色分级：DEFAULT_ADMIN / OPERATOR）
-- CEI 模式（Checks-Effects-Interactions）
-- 签名 nonce 防重放
-- 零地址检查
-- 超额 ETH 自动退还
-- SafeERC20（兼容非标准 ERC20）
-- Initializable 防护（_disableInitializers）
-
-## 测试覆盖
-
-| 模块 | 测试数 |
-|------|--------|
-| 核心铸造 | 9 |
-| 审计路径 | 20 |
-| Claim Conditions | 32 |
-| 压测 | 8 |
-| Factory Clone | 13 |
-| **总计** | **82** |
+| Layer | Stack |
+|-------|-------|
+| Contracts | Solidity 0.8.28 · ERC721A · OpenZeppelin 5 · Hardhat |
+| Frontend | Next.js 14 · viem · wagmi · Tailwind + DaisyUI |
+| Backend | Next.js API routes · Prisma 5 · SQLite |
+| Indexing | The Graph subgraph |
 
 ## License
 

--- a/docs/tutorial-agent-minting.md
+++ b/docs/tutorial-agent-minting.md
@@ -1,0 +1,109 @@
+# Tutorial: Agent-Native Minting
+
+**Time: ~20 minutes.** Your AI agent (any program holding a key — a
+scheduler, a webhook handler, an LLM tool call) creates a collection and
+issues mint grants. No crypto background required — everything is explained
+inline. This is the kit's differentiator: **the signer doesn't have to be a
+person.**
+
+## The idea in one diagram
+
+```
+┌─────────┐  deployCollection()  ┌──────────────┐
+│  AGENT  │ ───────────────────► │  Collection  │
+│ (key)   │  setTrustedSigner()  │  (contract)  │
+└────┬────┘ ───────────────────► └──────┬───────┘
+     │  signTypedData() (off-chain)     │ verifies sig on-chain
+     ▼                                  ▼
+  grant (sig + uid) ────────────────► mintWithSignature712V2()
+                                       ▲
+                            user (wallet) pays + gets NFT
+```
+
+## Part 1 — run the demo (10 minutes)
+
+The runnable example lives in [`scaffold-alchemy-main/examples/agent`](../scaffold-alchemy-main/examples/agent)
+with its own 10-minute guide ([README](../scaffold-alchemy-main/examples/agent/README.md)).
+It walks through the full loop: agent creates a collection → sets itself as
+trusted signer → signs a one-time grant → user mints → on-chain verification.
+
+```bash
+cd scaffold-alchemy-main/packages/hardhat
+npx hardhat node                       # terminal 1: local chain
+
+# terminal 2:
+cd scaffold-alchemy-main
+npx hardhat deploy --network localhost # deploy Factory + implementation
+
+# terminal 3:
+cd scaffold-alchemy-main/examples/agent
+npx tsx agent-issuance.ts              # the agent's whole day in one file
+```
+
+Expected output ends with:
+
+```
+[agent]  ✅ collection deployed at 0x… (owner: agent)
+[agent]  ✅ trusted signer = agent
+[agent]  ✅ grant signed — handing it to the user
+[user]   ✅ minted
+✅ Agent-native issuance loop completed
+```
+
+## Part 2 — register the agent's identity (5 minutes)
+
+The product layer ([#40](https://github.com/sijie-Z/nft-launchpad-kit/issues/40))
+gives agents an identity and makes every issuance auditable. With the dev
+server running:
+
+```bash
+# 1. Register the agent (its wallet address + capabilities)
+curl -X POST http://localhost:56900/api/agents \
+  -H "Content-Type: application/json" \
+  -d '{
+    "address": "0x<agent-address>",
+    "name": "QuestRewardBot",
+    "description": "Issues quest reward cards",
+    "capabilities": ["mint", "membership", "reward"]
+  }'
+
+# 2. Issue a grant as that agent (same call the demo signs, but audited)
+curl -X POST http://localhost:56900/api/signature \
+  -H "Content-Type: application/json" \
+  -d '{
+    "minter": "0x<user-address>",
+    "quantity": 1,
+    "maxMint": 5,
+    "deadline": <unix-ts-1h-from-now>,
+    "pricePerToken": 0,
+    "contractAddress": "0x<collection-address>",
+    "chainId": 31337,
+    "agentAddress": "0x<agent-address>"
+  }'
+# → { signature, uid, deadline, signer }
+
+# 3. Audit: the grant is recorded against the agent
+curl http://localhost:56900/api/agents/<agent-address>
+# → { ..., grants: [ { uid, minter, quantity, deadline, ... } ] }
+```
+
+The `uid` returned is the same value the contract checks for one-time use —
+the on-chain half of the trust trail. Nothing can be issued that isn't
+verifiable on-chain and recorded off-chain.
+
+## Turning this into real features
+
+- **Quest rewards** — webhook confirms a task → agent signs a grant → player mints
+- **Membership cards** — per purchase, agent signs; expiry = `deadline`
+- **Credentials** — signature grants + metadata = verifiable certificates
+- **Multi-agent** — one contract, one trusted signer; rotate with
+  `setTrustedSigner`, delegate operations with `OPERATOR_ROLE`
+
+## Production notes
+
+- The signing service lives server-side: `/api/signature` with
+  `SIGNER_PRIVATE_KEY` (rate-limited, validated). Agents call it like any web
+  service.
+- Rotating an agent = `setTrustedSigner(newAddress)` — old signatures stop
+  working instantly.
+- Mainnet deployment requires a professional audit (see `PROJECT.md`).

--- a/docs/tutorial-create-collection.md
+++ b/docs/tutorial-create-collection.md
@@ -1,0 +1,67 @@
+# Tutorial: Create a Collection, No Code
+
+**Time: ~10 minutes.** You'll deploy a real collection contract via the
+Factory (minimal-proxy clone, ~371k gas) using the admin wizard — no
+Solidity, no CLI.
+
+## 1. Start the app
+
+```bash
+cd scaffold-alchemy-main
+yarn workspace @scaffold-alchemy/nextjs dev
+```
+
+Open http://localhost:56900/admin and connect your wallet (the wizard runs on
+Sepolia or a local chain — see the multichain tutorial for networks).
+
+## 2. Open the creator wizard
+
+In the admin sidebar, pick **🚀 创建集合 (Create Collection)**. This is the
+no-code wizard, modeled on the thirdweb dashboard flow:
+
+```
+① 基本信息 → ② 链上部署 → ③ 平台注册 → ④ 完成引导
+```
+
+## 3. Fill in basic info
+
+- **Name / Symbol** — e.g. "Agent Club" / "AGT"
+- **Total supply** — e.g. 1000
+- **Per-wallet limit** — e.g. 5
+- **Price (ETH)** — e.g. 0.01
+- **Cover image** (optional) — paste a URL or upload via IPFS (the button
+  calls `/api/ipfs`; without Pinata keys it returns a dev-mode mock CID)
+
+> Tip: open the **⚡ AI 元数据生成** section — paste an image URL with the
+> `{id}` placeholder (e.g. `https://cdn.example.com/agents/{id}.png`), pick a
+> count, hit **🚀 生成并上传**. The pipeline generates `{id}.json` metadata
+> for every token and pins the whole folder in ONE request, returning
+> `ipfs://<cid>/` — exactly what the contract's Base URI needs.
+
+## 4. Deploy
+
+Click **下一步：链上部署 →** and **🚀 部署集合**. Your wallet signs one
+transaction that calls `Factory.deployCollection(...)`. The contract is a
+minimal proxy to the audited implementation — ~371k gas instead of ~5M.
+
+Wait for the receipt; the wizard parses the `CollectionCloned` event and shows
+your new contract address.
+
+## 5. Register + guided next steps
+
+**注册到平台 →** persists the collection (name, owner, contract address,
+Base URI) in the backend. You're auto-switched to the new collection's admin
+panel, with three shortcuts:
+
+- **⚡ Sale Control** — flip the sale on (or set up a whitelist phase first)
+- **💰 Royalty** — EIP-2981 receiver and rate
+- **📋 Whitelist** — CSV upload → Merkle root → allowlist minting
+
+## Done
+
+Your collection is live: mint page at `/collections/[id]`, admin at the
+sidebar. Total time without the optional metadata step: about 5 minutes.
+
+> Local chain? See [the multichain tutorial](tutorial-multichain.md) to deploy
+> the Factory on Sepolia/Base first, or run the wizard against a local Hardhat
+> node (chainId 31337 has a preconfigured Factory entry).

--- a/docs/tutorial-multichain.md
+++ b/docs/tutorial-multichain.md
@@ -1,0 +1,81 @@
+# Tutorial: Deploy to Sepolia & Base
+
+**Time: ~10 minutes.** One command per network, then verify on
+Etherscan/Basescan and point the frontend at your contracts.
+
+## Prerequisites
+
+```bash
+cd scaffold-alchemy-main
+cp .env.example .env
+```
+
+Fill in `.env`:
+
+| Variable | Needed for | Where to get it |
+|----------|-----------|-----------------|
+| `PRIVATE_KEY` | signing deploys | your deployer wallet (without `0x`) |
+| `ALCHEMY_API_KEY` | default RPC for both networks | https://dashboard.alchemy.com |
+| `ETHERSCAN_API_KEY` | Sepolia verification | https://etherscan.io/myapikey |
+| `BASESCAN_API_KEY` | Base verification | https://basescan.org/apis |
+
+Get test ETH: Sepolia — sepoliafaucet.com · Base Sepolia — the Coinbase faucet
+or bridge from Sepolia.
+
+## Deploy to Sepolia
+
+```bash
+yarn deploy:final
+```
+
+Deploys `NFTLaunchpadKit` (implementation) + `NFTLaunchpadKitFactory`.
+Verify:
+
+```bash
+yarn verify:sepolia      # preconfigured with the known addresses
+```
+
+## Deploy to Base Sepolia
+
+```bash
+yarn deploy:base         # npx hardhat deploy --network baseSepolia
+yarn verify:base         # needs the deployed addresses + BASESCAN_API_KEY
+```
+
+The deploy scripts are chain-agnostic — the same Factory + implementation
+pattern runs on both networks (deployment order is handled by hardhat-deploy
+dependencies).
+
+## Point the frontend at your contracts
+
+`packages/nextjs/contracts/deployedContracts.ts` is indexed by chainId.
+The `84532` (Base Sepolia) entry is pre-created; fill in the addresses after
+deploying:
+
+```ts
+84532: {
+  NFTLaunchpadKit: { address: "0x…", abi: [/* from deployments/baseSepolia/NFTLaunchpadKit.json */] },
+  NFTLaunchpadKitFactory: { address: "0x…", abi: [/* …Factory.json */] },
+},
+```
+
+The frontend reads `deployedContracts[chainId]` dynamically — the mint page,
+admin wizard and NetworkGuard all adapt once the entry exists. Until then they
+gracefully report "Factory not configured" on that network.
+
+## Supported networks
+
+| Network | Chain ID | RPC | Explorer |
+|---------|----------|-----|----------|
+| Sepolia | 11155111 | `SEPOLIA_RPC_URL` or Alchemy | etherscan.io |
+| Base Sepolia | 84532 | `BASE_SEPOLIA_RPC_URL` or Alchemy | basescan.org |
+
+`scaffold.config.ts` lists both (`targetNetworks`); the primary chain follows
+`config/chainConfig.json` (Sepolia by default).
+
+## CI deploys (optional)
+
+`.github/workflows/deploy.yml` deploys via GitHub Secrets
+(`PRIVATE_KEY` / `ALCHEMY_API_KEY` / `ETHERSCAN_API_KEY`) — set them in the
+`sepolia` environment under Settings → Environments, then trigger the
+workflow manually. No `.env` needed on the runner.


### PR DESCRIPTION
Closes #38

## 交付内容

**传播层（面向零币圈背景的 agent 开发者）：**

1. **README 英文重写** —— 以差异化开场："The agent issues. The user mints."，含功能/快速开始/测试/CI/分支模型/多链/安全
2. **3 篇教程（30 分钟闭环）**：
   - `docs/tutorial-create-collection.md` —— 无代码向导 10 分钟（含 AI 元数据）
   - `docs/tutorial-agent-minting.md` —— agent 全流程 20 分钟：demo → 身份注册 → 可审计授权（curl 示例）
   - `docs/tutorial-multichain.md` —— Sepolia/Base 一键部署 + 验证 + 前端接线

**部署准备（#15 前置）：**
3. `deploy.yml` 增加 network 输入（sepolia | baseSepolia）+ 按网络环境隔离 Secrets + BASESCAN_API_KEY

## 验收

- [x] 教程从零到"agent 发集合"≤30 分钟（demo 已实测）
- [x] 文档与代码同步（功能/测试数/命令均为当前状态）

> 中文文档保留在 PROJECT.md（已标历史快照）；README 转英文是面向受众的刻意选择。