### PR TITLE
[chore] 发布准备：LICENSE + CHANGELOG + 启动环境校验

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is based
+on [Keep a Changelog](https://keepachangelog.com/), and this project adheres
+to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added (post-v1.0.0 ideas)
+
+- Marketplace / post-mint liquidity layer (STRATEGY.md: the L2→L3 lever)
+- Token (ERC-20) issuance alongside NFTs
+
+## [1.0.0] - 2026-08-30
+
+### Added
+
+- **Smart contracts** (`packages/hardhat`)
+  - `NFTLaunchpadKit` — 6 mint modes (public, allowlist, Dutch auction,
+    signature legacy + EIP-712, ERC20, phased claim conditions), Factory
+    Clone (ERC-1167), EIP-2981 royalties, delayed reveal, Feistel tokenURI
+    shuffle (bijective via cycle-walking), 28 custom errors, 37 events
+  - `NFTLaunchpadKitFactory` — clone deploys (93% gas savings), CREATE2
+    deterministic deploys with caller-bound salts (front-run resistant)
+  - 100 tests incl. exhaustive bijectivity checks; Slither-reviewed
+- **Creator product layer** (M4)
+  - No-code collection wizard (admin 🚀 tab): deploy via Factory → register
+    → guided setup
+  - AI metadata pipeline: generate + pin 1000 token metadata files in ONE
+    IPFS request (`/api/metadata/generate`)
+  - Agent identity registry + grant audit trail (`Agent`/`AgentGrant`,
+    wired into `/api/signature`)
+  - Runnable agent-native issuance example (`examples/agent`) + 10-min guide
+- **Infrastructure**
+  - CI: contract tests + frontend type/test/lint in parallel (~3–4 min),
+    real `next build` on merge, manual multi-network deploy workflow
+  - Multi-chain: Sepolia + Base Sepolia (one-command deploys)
+  - English docs: README + 3 tutorials (create / agent mint / multichain)
+
+### Fixed
+
+- Hardcoded Alchemy API keys removed from the repo (rotate them!)
+- `next build` actually passes (prisma generate postinstall; removed the
+  `IGNORE_BUILD_ERROR` escape hatch)
+- Feistel shuffle non-bijectivity → tokenURI collisions (cycle-walking fix)
+- Payout split mode could not be cleared / dust could never be recovered
+- CREATE2 salt front-running (caller-bound salts)
+- hardhat `check-types` clean (13 → 0 errors); dead code removed (AA deploy
+  chain, unused errors, unused deps)
+- npm/yarn dual lockfiles (yarn is the single source of truth)
+- Test hygiene: `restoreAllMocks()` vs `vi.fn()` call-history leak
+
+### Security
+
+- Slither 0.11.6: 44 findings, all acceptable/benign after fixes
+- Mainnet deployment requires a professional audit (see PROJECT.md)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 sijie-Z
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scaffold-alchemy-main/packages/nextjs/instrumentation.ts
+++ b/scaffold-alchemy-main/packages/nextjs/instrumentation.ts
@@ -1,0 +1,23 @@
+/**
+ * Next.js instrumentation — runs once when the server starts.
+ * Validates required environment variables so misconfiguration fails fast
+ * with a clear message instead of failing later in opaque ways.
+ * (Wired up per the env.ts design — it was previously only tested, never called.)
+ */
+export async function register() {
+  const { validateEnv } = await import("./lib/env");
+  const result = validateEnv();
+
+  if (result.valid) {
+    if (result.warnings.length > 0) {
+      console.warn("[env] optional vars missing: " + result.warnings.join(", "));
+    }
+    return;
+  }
+
+  const msg = "[env] Missing required vars: " + result.missing.join(", ") + ". Copy .env.example to .env and fill them in.";
+  if (process.env.NODE_ENV === "production") {
+    throw new Error(msg); // fail fast in production
+  }
+  console.error(msg); // warn loudly in development
+}


### PR DESCRIPTION
v1.0.0 发布准备（#17 的前置）：

1. **LICENSE（MIT）** —— 仓库根目录此前没有任何许可证（scaffold 里的 MIT 是 Alchemy 模板版权），开源项目/简历的门面
2. **CHANGELOG.md** —— v1.0.0 完整条目（Keep a Changelog 格式）+ Unreleased 方向（市场/流动性、token 发行）
3. **instrumentation.ts** —— `validateEnv()` 首次真正在启动时运行（此前只定义+测试、从未被调用）：生产缺必填变量快速失败，开发环境响亮警告

验证：tsc 0 · vitest 104/104 · next build EXIT 0