### PR TITLE
[Phase 1A] Agent SDK MVP + 最小 API 认证

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,11 @@ jobs:
         run: yarn hardhat:lint
         working-directory: scaffold-alchemy-main
 
+      - name: SDK typecheck
+        run: yarn workspace @nft-launchpad-kit/sdk check-types
+        working-directory: scaffold-alchemy-main
+
+      - name: SDK tests
+        run: yarn workspace @nft-launchpad-kit/sdk test
+        working-directory: scaffold-alchemy-main
+

--- a/scaffold-alchemy-main/.env.example
+++ b/scaffold-alchemy-main/.env.example
@@ -40,3 +40,7 @@ PINATA_JWT=
 # Base Sepolia (#37) — deploy target for the agent economy chain
 BASE_SEPOLIA_RPC_URL=
 BASESCAN_API_KEY=
+
+# Platform API key for cross-origin writes (SDK/agent calls).
+# Same-origin frontend requests are exempt; leave empty to keep writes open.
+PLATFORM_API_KEY=

--- a/scaffold-alchemy-main/package.json
+++ b/scaffold-alchemy-main/package.json
@@ -6,6 +6,7 @@
     "packages": [
       "packages/hardhat",
       "packages/nextjs",
+      "packages/sdk",
       "examples/agent"
     ]
   },

--- a/scaffold-alchemy-main/packages/nextjs/__tests__/api/middleware.test.ts
+++ b/scaffold-alchemy-main/packages/nextjs/__tests__/api/middleware.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import { middleware } from "../../middleware";
+
+function makeReq(url: string, opts: { method?: string; origin?: string; auth?: string } = {}) {
+  const headers: Record<string, string> = {};
+  if (opts.origin) headers.origin = opts.origin;
+  if (opts.auth) headers.authorization = opts.auth;
+  return new NextRequest(url, { method: opts.method ?? "GET", headers });
+}
+
+function isNext(res: NextResponse): boolean {
+  return res.status === 200 && res.headers.get("x-middleware-next") === "1";
+}
+
+describe("API auth middleware (Phase 1A)", () => {
+  beforeEach(() => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("PLATFORM_API_KEY", "test-platform-key");
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("passes read endpoints without auth", () => {
+    const res = middleware(makeReq("http://localhost/api/collections/abc"));
+    expect(isNext(res)).toBe(true);
+  });
+
+  it("rejects cross-origin writes without the key", () => {
+    const res = middleware(
+      makeReq("http://localhost/api/signature", { method: "POST", origin: "https://evil.example.com" }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("accepts cross-origin writes with the correct key", () => {
+    const res = middleware(
+      makeReq("http://localhost/api/signature", {
+        method: "POST",
+        origin: "https://evil.example.com",
+        auth: "Bearer test-platform-key",
+      }),
+    );
+    expect(isNext(res)).toBe(true);
+  });
+
+  it("rejects a wrong key", () => {
+    const res = middleware(
+      makeReq("http://localhost/api/collections", {
+        method: "POST",
+        origin: "https://evil.example.com",
+        auth: "Bearer wrong",
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("exempts same-origin browser writes (our own frontend)", () => {
+    const res = middleware(
+      makeReq("http://localhost/api/collections", { method: "POST", origin: "http://localhost" }),
+    );
+    expect(isNext(res)).toBe(true);
+  });
+
+  it("leaves writes open when PLATFORM_API_KEY is not configured (backward compatible)", () => {
+    vi.stubEnv("PLATFORM_API_KEY", undefined);
+    const res = middleware(
+      makeReq("http://localhost/api/metadata/generate", { method: "POST", origin: "https://evil.example.com" }),
+    );
+    expect(isNext(res)).toBe(true);
+  });
+
+  it("skips the check outside production (local dev)", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const res = middleware(
+      makeReq("http://localhost/api/signature", { method: "POST", origin: "https://evil.example.com" }),
+    );
+    expect(isNext(res)).toBe(true);
+  });
+});

--- a/scaffold-alchemy-main/packages/nextjs/app/api/signature/config/route.ts
+++ b/scaffold-alchemy-main/packages/nextjs/app/api/signature/config/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { privateKeyToAccount } from "viem/accounts";
+
+/**
+ * GET /api/signature/config — public read: the platform's signing address.
+ * Collections created via the SDK should trust this address:
+ *   kit.collections.create(input, { trustedSigner: await kit.grants.getSigner() })
+ * The address is not a secret (it is already returned by every /api/signature
+ * response); only the private key is.
+ */
+export async function GET() {
+  const privateKey = process.env.SIGNER_PRIVATE_KEY;
+  if (!privateKey) {
+    return NextResponse.json({ signer: null, configured: false }, { status: 200 });
+  }
+  const key = privateKey.startsWith("0x") ? privateKey : `0x${privateKey}`;
+  const account = privateKeyToAccount(key as `0x${string}`);
+  return NextResponse.json({ signer: account.address, configured: true });
+}

--- a/scaffold-alchemy-main/packages/nextjs/middleware.ts
+++ b/scaffold-alchemy-main/packages/nextjs/middleware.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Minimal API auth (Phase 1A).
+ *
+ * Model:
+ *   - Write endpoints require `Authorization: Bearer <PLATFORM_API_KEY>`
+ *     for cross-origin callers (the SDK, other servers, agents).
+ *   - Same-origin browser requests (our own frontend) are exempt — the
+ *     platform's own UI is a first-class consumer and cannot hold a secret.
+ *   - Read endpoints stay public.
+ *   - If PLATFORM_API_KEY is not configured, writes stay open (opt-in auth,
+ *     backward compatible with existing deployments).
+ *   - Non-production environments skip the check entirely (local dev).
+ *
+ * This is a compatibility strategy, not a complete security boundary —
+ * dangerous endpoints (metadata/signature/collections) additionally carry
+ * per-IP rate limits, and the signing service's real secret is
+ * SIGNER_PRIVATE_KEY. A full per-agent key model is v2.
+ */
+const WRITE_PREFIXES = ["/api/agents", "/api/collections", "/api/signature", "/api/metadata/generate"];
+const WRITE_METHODS = ["POST", "PUT", "PATCH", "DELETE"];
+
+function isWritePath(pathname: string): boolean {
+  return WRITE_PREFIXES.some(p => pathname === p || pathname.startsWith(`${p}/`));
+}
+
+function isSameOrigin(req: NextRequest): boolean {
+  const origin = req.headers.get("origin");
+  if (!origin) return false;
+  try {
+    return new URL(origin).host === req.nextUrl.host;
+  } catch {
+    return false;
+  }
+}
+
+export function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+  const isWrite = WRITE_METHODS.includes(req.method) && isWritePath(pathname);
+  if (!pathname.startsWith("/api/") || !isWrite) {
+    return NextResponse.next(); // reads stay public
+  }
+  if (process.env.NODE_ENV !== "production") {
+    return NextResponse.next(); // local dev / tests
+  }
+  if (isSameOrigin(req)) {
+    return NextResponse.next(); // our own frontend
+  }
+
+  const platformKey = process.env.PLATFORM_API_KEY;
+  if (!platformKey) {
+    return NextResponse.next(); // auth not configured → open (backward compatible)
+  }
+  const auth = req.headers.get("authorization");
+  if (auth === `Bearer ${platformKey}`) {
+    return NextResponse.next();
+  }
+  return NextResponse.json({ error: "Unauthorized — missing or invalid API key" }, { status: 401 });
+}
+
+export const config = {
+  matcher: ["/api/:path*"],
+};

--- a/scaffold-alchemy-main/packages/sdk/README.md
+++ b/scaffold-alchemy-main/packages/sdk/README.md
@@ -1,0 +1,92 @@
+# @nft-launchpad-kit/sdk
+
+**The agent issues. The user mints.**
+
+A TypeScript SDK for agent-native NFT issuance. Give your agent a wallet and
+it can create collections, sign one-time mint grants, generate metadata, and
+execute mints — through three levels of API:
+
+| Level | Methods | For |
+|-------|---------|-----|
+| **1 · Goal** | `collections.create` · `grants.issue` · `metadata.generate` · `mint.execute` | agents (default) |
+| **2 · Resource** | `collections.get/list` · `grants.verify` · `agents.get` | queries |
+| **3 · Primitive** | `collections.deploy` · `collections.register` | advanced control |
+
+## Install
+
+```bash
+npm install @nft-launchpad-kit/sdk
+```
+
+Requires a running [NFT Launchpad Kit](https://github.com/sijie-Z/nft-launchpad-kit)
+instance (the platform provides the signing service, agent registry and
+metadata pipeline).
+
+## 10-minute first issuance
+
+```ts
+import { LaunchpadKit } from "@nft-launchpad-kit/sdk";
+import { privateKeyToAccount } from "viem/accounts";
+
+const kit = new LaunchpadKit({
+  baseUrl: "https://your-instance.example.com", // your platform instance
+  apiKey: process.env.NLA_API_KEY,              // platform API key
+  chain: "base-sepolia",
+  wallet: privateKeyToAccount(process.env.AGENT_PRIVATE_KEY!), // your agent's key
+});
+
+// 1. Register the agent's identity (audit trail)
+await kit.agents.register({
+  address: kit.config.wallet.address,
+  name: "QuestRewardBot",
+  capabilities: ["mint", "membership"],
+});
+
+// 2. Create a collection — one call: deploy via Factory + trust the signer + register
+const signer = await kit.grants.getSigner();
+const collection = await kit.collections.create(
+  { name: "AI Founder Pass", symbol: "AFP", supply: 1000, price: "0.01" },
+  { trustedSigner: signer },
+);
+
+// 3. Issue a one-time mint grant for a user
+const grant = await kit.grants.issue({
+  collectionAddress: collection.contractAddress!,
+  minter: userAddress,
+  quantity: 1,
+  agentAddress: kit.config.wallet.address,
+});
+
+// 4. The user mints (the wallet pays the mint price + gas)
+await kit.mint.execute({ collectionAddress: collection.contractAddress!, grant });
+
+// 5. Verify: the grant's UID is burned — replay reverts on-chain
+const used = await kit.grants.verify(collection.contractAddress!, grant.uid);
+```
+
+That's it: **create → issue → mint**. The contract verifies the signature
+on-chain (trusted signer, deadline, one-time UID) before minting anything.
+
+## Concepts (30 seconds)
+
+- **Agent** = any program holding a private key. The contract's
+  `trustedSigner` is the only address whose signatures can authorize mints.
+- **Grant** = an off-chain signature (`{minter, quantity, maxMint, deadline,
+  pricePerToken, uid}`), one-time via UID, expiring via deadline.
+- **Collection** = an ERC-721A collection deployed as a minimal-proxy clone
+  (~371k gas) — the platform's Factory handles it.
+
+## Local demo (dogfood)
+
+See [`examples/agent-issuance.ts`](examples/agent-issuance.ts) — runs the full
+loop against a local Hardhat chain + a local platform server (three terminals,
+instructions in the file header).
+
+## Supported chains
+
+`sepolia` (11155111) · `base-sepolia` (84532, after the Factory is deployed) ·
+`localhost` (31337, for the local demo).
+
+## License
+
+MIT

--- a/scaffold-alchemy-main/packages/sdk/__tests__/sdk.test.ts
+++ b/scaffold-alchemy-main/packages/sdk/__tests__/sdk.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { privateKeyToAccount } from "viem/accounts";
+import { LaunchpadKit } from "../src/index";
+import { ApiError } from "../src/client";
+
+const AGENT_KEY = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
+const USER_ADDR = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC";
+
+function makeKit(overrides: Partial<Parameters<typeof LaunchpadKit.prototype.constructor>[0]> = {}) {
+  return new LaunchpadKit({
+    baseUrl: "http://localhost:56900",
+    chain: "localhost",
+    wallet: privateKeyToAccount(AGENT_KEY),
+    ...overrides,
+  });
+}
+
+function mockFetchOnce(json: unknown, ok = true, status = 200) {
+  return vi.fn().mockResolvedValue({ ok, status, json: () => Promise.resolve(json) });
+}
+
+describe("LaunchpadKit — API layer", () => {
+  beforeEach(() => vi.unstubAllGlobals());
+
+  it("sends the api key as a Bearer header on writes", async () => {
+    const fetchMock = mockFetchOnce({ id: "a1" });
+    vi.stubGlobal("fetch", fetchMock);
+    const kit = makeKit({ apiKey: "secret-key" });
+
+    await kit.agents.register({ address: USER_ADDR, name: "Bot" });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://localhost:56900/api/agents");
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer secret-key");
+  });
+
+  it("omits the auth header when no api key is configured", async () => {
+    const fetchMock = mockFetchOnce([]);
+    vi.stubGlobal("fetch", fetchMock);
+    const kit = makeKit();
+
+    await kit.collections.list();
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init.headers as Record<string, string>).Authorization).toBeUndefined();
+  });
+
+  it("agents.register posts the identity and normalizes the body", async () => {
+    const fetchMock = mockFetchOnce({ id: "a1", address: USER_ADDR.toLowerCase() });
+    vi.stubGlobal("fetch", fetchMock);
+    const kit = makeKit();
+
+    await kit.agents.register({ address: USER_ADDR, name: "QuestBot", capabilities: ["mint"] });
+
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init.body as string);
+    expect(body.name).toBe("QuestBot");
+    expect(body.capabilities).toEqual(["mint"]);
+  });
+
+  it("collections.register posts the collection to /api/collections", async () => {
+    const fetchMock = mockFetchOnce({ id: "c1", contractAddress: USER_ADDR.toLowerCase() });
+    vi.stubGlobal("fetch", fetchMock);
+    const kit = makeKit();
+
+    await kit.collections.register({
+      name: "Agent Club",
+      symbol: "AGT",
+      supply: 1000,
+      price: "0.01",
+      contractAddress: USER_ADDR,
+      ownerAddress: USER_ADDR,
+      chainId: 31337,
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://localhost:56900/api/collections");
+    const body = JSON.parse(init.body as string);
+    expect(body.name).toBe("Agent Club");
+    expect(body.contractAddress).toBe(USER_ADDR);
+    expect(body.chainId).toBe(31337);
+  });
+
+  it("grants.issue posts to /api/signature with the collection address and chain", async () => {
+    const fetchMock = mockFetchOnce({
+      signature: "0xabc",
+      uid: "0xuid",
+      deadline: 123,
+      signer: "0xsigner",
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const kit = makeKit();
+
+    const grant = await kit.grants.issue({
+      collectionAddress: USER_ADDR,
+      minter: USER_ADDR,
+      quantity: 1,
+      agentAddress: USER_ADDR,
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init.body as string);
+    expect(body.contractAddress).toBe(USER_ADDR);
+    expect(body.chainId).toBe(31337);
+    expect(body.agentAddress).toBe(USER_ADDR);
+    expect(body.maxMint).toBe(5); // default
+    // response merged with the request so mint() has everything it needs
+    expect(grant.quantity).toBe(1);
+    expect(grant.maxMint).toBe(5);
+    expect(grant.pricePerToken).toBe(0);
+  });
+
+  it("grants.getSigner fetches the platform signer", async () => {
+    const fetchMock = mockFetchOnce({ signer: "0xsigner", configured: true });
+    vi.stubGlobal("fetch", fetchMock);
+    const kit = makeKit();
+
+    expect(await kit.grants.getSigner()).toBe("0xsigner");
+    expect(fetchMock.mock.calls[0][0]).toBe("http://localhost:56900/api/signature/config");
+  });
+
+  it("metadata.generate posts to /api/metadata/generate", async () => {
+    const fetchMock = mockFetchOnce({ baseUri: "ipfs://QmMock/", count: 10, mock: true });
+    vi.stubGlobal("fetch", fetchMock);
+    const kit = makeKit();
+
+    const res = await kit.metadata.generate({ name: "Agent Club", imageUrl: "https://x/{id}.png", count: 10 });
+    expect(res.baseUri).toBe("ipfs://QmMock/");
+    expect(fetchMock.mock.calls[0][0]).toBe("http://localhost:56900/api/metadata/generate");
+  });
+
+  it("surfaces server errors as ApiError with status", async () => {
+    const fetchMock = mockFetchOnce({ error: "Missing required fields" }, false, 400);
+    vi.stubGlobal("fetch", fetchMock);
+    const kit = makeKit();
+
+    await expect(
+      kit.agents.register({ address: USER_ADDR, name: "" }),
+    ).rejects.toMatchObject({ status: 400, message: "Missing required fields" });
+    expect(ApiError.prototype instanceof Error).toBe(true);
+  });
+});

--- a/scaffold-alchemy-main/packages/sdk/examples/agent-issuance.ts
+++ b/scaffold-alchemy-main/packages/sdk/examples/agent-issuance.ts
@@ -1,0 +1,85 @@
+/**
+ * Agent-native issuance demo — via @nft-launchpad-kit/sdk (dogfood).
+ *
+ * The AGENT (a program holding a key) does everything through the SDK:
+ *   1. create a collection (deploy via Factory + register + trust the signer)
+ *   2. issue a one-time mint grant for a user
+ *   3. the user mints with the grant
+ *
+ * Prereqs (three terminals):
+ *   # 1 — local chain
+ *   cd scaffold-alchemy-main/packages/hardhat && npx hardhat node
+ *   # 2 — deploy + platform server (SIGNER_PRIVATE_KEY must be the server signer)
+ *   cd scaffold-alchemy-main && npx hardhat deploy --network localhost
+ *   SIGNER_PRIVATE_KEY=… yarn workspace @scaffold-alchemy/nextjs dev
+ *   # 3 — this demo
+ *   cd packages/sdk && npx tsx examples/agent-issuance.ts
+ */
+import "dotenv/config";
+import { privateKeyToAccount } from "viem/accounts";
+import { LaunchpadKit } from "../src/index";
+
+const agentKey = (process.env.AGENT_PRIVATE_KEY ??
+  "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d") as `0x${string}`; // hardhat #1
+const userKey = (process.env.USER_PRIVATE_KEY ??
+  "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a") as `0x${string}`; // hardhat #2
+
+const kit = new LaunchpadKit({
+  baseUrl: process.env.BASE_URL ?? "http://127.0.0.1:56900",
+  apiKey: process.env.NLA_API_KEY,
+  chain: "localhost",
+  wallet: privateKeyToAccount(agentKey),
+  rpcUrl: process.env.RPC_URL ?? "http://127.0.0.1:8545",
+});
+
+async function main() {
+  const agent = kit.config.wallet;
+  const user = privateKeyToAccount(userKey);
+  console.log(`[agent]  ${agent.address.slice(0, 10)}… starting (SDK @nft-launchpad-kit/sdk)`);
+
+  // 0. Register the agent's identity (audit trail)
+  await kit.agents.register({
+    address: agent.address,
+    name: "AgentClubBot",
+    description: "SDK dogfood demo agent",
+    capabilities: ["mint", "membership"],
+  });
+  console.log("[agent]  identity registered");
+
+  // 1. Goal API: create a collection (deploy + trust the platform signer + register)
+  const signer = await kit.grants.getSigner();
+  const collection = await kit.collections.create(
+    { name: "Agent Club", symbol: "AGT", supply: 1000, price: "0.01" },
+    { trustedSigner: signer },
+  );
+  console.log(`[agent]  ✅ collection ${collection.name} @ ${collection.contractAddress?.slice(0, 10)}…`);
+
+  // 2. Goal API: issue a one-time grant for the user
+  const grant = await kit.grants.issue({
+    collectionAddress: collection.contractAddress!,
+    minter: user.address,
+    quantity: 1,
+    agentAddress: agent.address,
+  });
+  console.log(`[agent]  ✅ grant issued (uid ${grant.uid.slice(0, 10)}…)`);
+
+  // 3. Goal API: the user mints (the minter's wallet pays)
+  await kit.mint.execute({
+    collectionAddress: collection.contractAddress!,
+    grant,
+    minter: user,
+  });
+  console.log("[user]   ✅ minted");
+
+  // 4. Resource API: verify
+  const owner = await kit.collections.get(collection.id);
+  console.log(`[verify] collection status: ${owner.status}`);
+  const uidUsed = await kit.grants.verify(collection.contractAddress!, grant.uid);
+  console.log(`[verify] uid one-time: ${uidUsed} (true = consumed, reuse reverts)`);
+  console.log("\n✅ Done — the agent issued, the user minted, all through the SDK.");
+}
+
+main().catch(err => {
+  console.error("\n❌ demo failed:", err?.message ?? err);
+  process.exit(1);
+});

--- a/scaffold-alchemy-main/packages/sdk/package.json
+++ b/scaffold-alchemy-main/packages/sdk/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@nft-launchpad-kit/sdk",
+  "version": "0.1.0",
+  "description": "Agent-native NFT issuance SDK — the agent issues, the user mints. Create collections, sign grants, generate metadata, execute mints.",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "check-types": "tsc --noEmit",
+    "test": "vitest run",
+    "demo": "tsx examples/agent-issuance.mjs"
+  },
+  "dependencies": {
+    "viem": "^2.13.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "dotenv": "^17.4.2",
+    "tsx": "^4.19.0",
+    "typescript": "^5.5.0",
+    "vitest": "^4.1.5"
+  }
+}

--- a/scaffold-alchemy-main/packages/sdk/src/abis.ts
+++ b/scaffold-alchemy-main/packages/sdk/src/abis.ts
@@ -1,0 +1,262 @@
+// Minimal ABIs embedded so the SDK is self-contained (no monorepo imports at runtime).
+export const factoryAbi = [
+  {
+    "type": "function",
+    "name": "deployCollection",
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "name_",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "symbol_",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxSupply",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxPerWallet",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "mintPrice",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "clone",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "CollectionCloned",
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "cloneAddress",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "symbol",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "maxSupply",
+        "type": "uint256"
+      }
+    ],
+    "anonymous": false
+  }
+] as const;
+
+export const kitAbi = [
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_initialOwner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_mintPrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxSupply",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxPerWallet",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "uid",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isSignatureUsed",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "mintPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "quantity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxMint",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "pricePerToken",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "uid",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "signature",
+        "type": "bytes"
+      }
+    ],
+    "name": "mintWithSignature712V2",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "ownerOf",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "signer",
+        "type": "address"
+      }
+    ],
+    "name": "setTrustedSigner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "result",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "trustedSigner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+] as const;

--- a/scaffold-alchemy-main/packages/sdk/src/agents.ts
+++ b/scaffold-alchemy-main/packages/sdk/src/agents.ts
@@ -1,0 +1,15 @@
+import { ApiClient } from "./client";
+import type { Agent, AgentDetail, AgentInput } from "./types";
+
+/** Agents — identity registry: register an agent, audit its issuance history. */
+export class Agents {
+  constructor(private client: ApiClient) {}
+
+  async register(input: AgentInput): Promise<Agent> {
+    return this.client.request("/api/agents", { method: "POST", body: JSON.stringify(input) });
+  }
+
+  async get(address: string): Promise<AgentDetail> {
+    return this.client.request(`/api/agents/${address.toLowerCase()}`);
+  }
+}

--- a/scaffold-alchemy-main/packages/sdk/src/client.ts
+++ b/scaffold-alchemy-main/packages/sdk/src/client.ts
@@ -1,0 +1,46 @@
+import type { PrivateKeyAccount } from "viem/accounts";
+import type { ChainId } from "./types";
+
+export interface LaunchpadKitConfig {
+  /** Base URL of your NFT Launchpad Kit instance. */
+  baseUrl: string;
+  /** Platform API key (required for cross-origin writes when the server sets PLATFORM_API_KEY). */
+  apiKey?: string;
+  /** Target chain: "sepolia" | "base-sepolia" | "localhost". */
+  chain: ChainId;
+  /** The wallet that acts as the agent (signs deployments, pays gas for deploy/mint). */
+  wallet: PrivateKeyAccount;
+  /** Optional RPC override (defaults to the chain's public RPC). */
+  rpcUrl?: string;
+}
+
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+/** Thin fetch wrapper over the platform REST API (Level 3 — API layer). */
+export class ApiClient {
+  constructor(private config: LaunchpadKitConfig) {}
+
+  async request<T>(path: string, init?: RequestInit): Promise<T> {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (this.config.apiKey) {
+      headers.Authorization = `Bearer ${this.config.apiKey}`;
+    }
+    const res = await fetch(`${this.config.baseUrl}${path}`, {
+      ...init,
+      headers: { ...headers, ...(init?.headers ?? {}) },
+    });
+    const body = await res.json().catch(() => null);
+    if (!res.ok) {
+      throw new ApiError(res.status, body?.error ?? `Request failed with status ${res.status}`);
+    }
+    return body as T;
+  }
+}

--- a/scaffold-alchemy-main/packages/sdk/src/collections.ts
+++ b/scaffold-alchemy-main/packages/sdk/src/collections.ts
@@ -1,0 +1,127 @@
+import {
+  createPublicClient,
+  createWalletClient,
+  http,
+  parseEther,
+  parseEventLogs,
+} from "viem";
+import { baseSepolia, hardhat, sepolia } from "viem/chains";
+import type { Address, Chain } from "viem";
+import { ApiClient, type LaunchpadKitConfig } from "./client";
+import { factoryAbi, kitAbi } from "./abis";
+import type { ChainId, Collection, CollectionInput, RegisterInput } from "./types";
+
+const FACTORY_ADDRESSES: Record<ChainId, Address | null> = {
+  sepolia: "0x1e320041d3106022965C7846EE7bcbceab65a8e1",
+  "base-sepolia": null, // set after Phase 0 deploy
+  localhost: "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+};
+
+const CHAIN_IDS: Record<ChainId, number> = { sepolia: 11155111, "base-sepolia": 84532, localhost: 31337 };
+
+export function viemChain(chain: ChainId): Chain {
+  switch (chain) {
+    case "sepolia":
+      return sepolia;
+    case "base-sepolia":
+      return baseSepolia;
+    default:
+      return hardhat;
+  }
+}
+
+/** Collections — Level 1 create() (goal), Level 2 get/list (resources), Level 3 deploy/register (primitives). */
+export class Collections {
+  constructor(
+    private client: ApiClient,
+    private config: LaunchpadKitConfig,
+  ) {}
+
+  // ── Level 3: chain primitive ──────────────────────────────────────────────
+
+  /** Deploy a collection via the Factory (clone, ~371k gas). The wallet pays gas. */
+  async deploy(input: CollectionInput): Promise<{ contractAddress: Address }> {
+    const factory = FACTORY_ADDRESSES[this.config.chain];
+    if (!factory) {
+      throw new Error(`Factory not configured for chain "${this.config.chain}" — deploy it first (Phase 0).`);
+    }
+    const chain = viemChain(this.config.chain);
+    const publicClient = createPublicClient({ chain, transport: http(this.config.rpcUrl) });
+    const walletClient = createWalletClient({ account: this.config.wallet, chain, transport: http(this.config.rpcUrl) });
+
+    const txHash = await walletClient.writeContract({
+      address: factory,
+      abi: factoryAbi,
+      functionName: "deployCollection",
+      args: [input.name, input.symbol, BigInt(input.supply), BigInt(input.maxPerWallet ?? 5), parseEther(input.price)],
+    });
+    const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+    const [event] = parseEventLogs({ logs: receipt.logs, abi: factoryAbi, eventName: "CollectionCloned" });
+    if (!event) throw new Error("Deploy succeeded but CollectionCloned event was not found");
+    return { contractAddress: event.args.cloneAddress };
+  }
+
+  // ── Level 3: API primitive ────────────────────────────────────────────────
+
+  /** Register an already-deployed collection in the platform backend. */
+  async register(input: RegisterInput): Promise<Collection> {
+    return this.client.request("/api/collections", {
+      method: "POST",
+      body: JSON.stringify({
+        name: input.name,
+        symbol: input.symbol,
+        maxSupply: input.supply,
+        mintPrice: input.price,
+        maxPerWallet: input.maxPerWallet ?? 5,
+        contractAddress: input.contractAddress,
+        ownerAddress: input.ownerAddress,
+        chainId: input.chainId,
+        description: input.description,
+        coverImage: input.coverImage,
+        baseURI: input.baseURI,
+      }),
+    });
+  }
+
+  // ── Level 1: goal ─────────────────────────────────────────────────────────
+
+  /**
+   * Deploy + register in one call — the "10-minute issuance" path.
+   * @param opts.trustedSigner — address authorized to sign grants for this
+   *   collection (typically the platform signer, see grants.getSigner()).
+   */
+  async create(input: CollectionInput, opts?: { trustedSigner?: Address }): Promise<Collection> {
+    const { contractAddress } = await this.deploy(input);
+    if (opts?.trustedSigner) {
+      const chain = viemChain(this.config.chain);
+      const walletClient = createWalletClient({
+        account: this.config.wallet,
+        chain,
+        transport: http(this.config.rpcUrl),
+      });
+      await walletClient.writeContract({
+        address: contractAddress,
+        abi: kitAbi,
+        functionName: "setTrustedSigner",
+        args: [opts.trustedSigner],
+      });
+    }
+    return this.register({
+      ...input,
+      contractAddress,
+      ownerAddress: this.config.wallet.address,
+      chainId: CHAIN_IDS[this.config.chain],
+    });
+  }
+
+  // ── Level 2: resources ────────────────────────────────────────────────────
+
+  async get(id: string): Promise<Collection> {
+    return this.client.request(`/api/collections/${id}`);
+  }
+
+  async list(params: Record<string, string | number> = {}): Promise<{ collections: Collection[]; total: number }> {
+    const qs = new URLSearchParams(Object.entries(params).map(([k, v]) => [k, String(v)])).toString();
+    return this.client.request(`/api/collections${qs ? `?${qs}` : ""}`);
+  }
+}

--- a/scaffold-alchemy-main/packages/sdk/src/grants.ts
+++ b/scaffold-alchemy-main/packages/sdk/src/grants.ts
@@ -1,0 +1,66 @@
+import { createPublicClient, http } from "viem";
+import type { Address } from "viem";
+import { ApiClient, type LaunchpadKitConfig } from "./client";
+import { kitAbi } from "./abis";
+import { viemChain } from "./collections";
+import type { Grant, GrantInput } from "./types";
+
+const DEFAULT_MAX_MINT = 5;
+const DEFAULT_DEADLINE_S = 3600; // 1 hour
+
+/**
+ * Grants — the core differentiator: a program signs, a user mints.
+ *
+ * Level 1: issue() — off-chain authorization via the platform signing service.
+ * Level 2: verify() — on-chain one-time check (the UID is burned on first use).
+ */
+export class Grants {
+  constructor(
+    private client: ApiClient,
+    private config: LaunchpadKitConfig,
+  ) {}
+
+  /** Issue a mint grant (EIP-712 V2, one-time UID, expiring). */
+  async issue(input: GrantInput): Promise<Grant> {
+    const deadline = input.deadline ?? Math.floor(Date.now() / 1000) + DEFAULT_DEADLINE_S;
+    const maxMint = input.maxMint ?? DEFAULT_MAX_MINT;
+    const pricePerToken = input.pricePerToken ?? 0;
+    const res = await this.client.request<{ signature: string; uid: string; deadline: number; signer: string }>(
+      "/api/signature",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          minter: input.minter,
+          quantity: input.quantity,
+          maxMint,
+          deadline,
+          pricePerToken,
+          contractAddress: input.collectionAddress,
+          chainId: this.config.chain === "localhost" ? 31337 : this.config.chain === "sepolia" ? 11155111 : 84532,
+          agentAddress: input.agentAddress,
+        }),
+      },
+    );
+    return { ...res, quantity: input.quantity, maxMint, pricePerToken };
+  }
+
+  /** The platform's signing address (what collections must trust via create({ trustedSigner })). */
+  async getSigner(): Promise<string> {
+    const res = await this.client.request<{ signer: string }>("/api/signature/config");
+    return res.signer;
+  }
+
+  /** Verify a grant's UID is still unused on-chain (false after first mint). */
+  async verify(collectionAddress: Address, uid: string): Promise<boolean> {
+    const publicClient = createPublicClient({
+      chain: viemChain(this.config.chain),
+      transport: http(this.config.rpcUrl),
+    });
+    return publicClient.readContract({
+      address: collectionAddress,
+      abi: kitAbi,
+      functionName: "isSignatureUsed",
+      args: [uid as `0x${string}`],
+    });
+  }
+}

--- a/scaffold-alchemy-main/packages/sdk/src/index.ts
+++ b/scaffold-alchemy-main/packages/sdk/src/index.ts
@@ -1,0 +1,41 @@
+import { Agents } from "./agents";
+import { ApiClient, type LaunchpadKitConfig } from "./client";
+import { Collections } from "./collections";
+import { Grants } from "./grants";
+import { Metadata } from "./metadata";
+import { Mint } from "./mint";
+
+export type { LaunchpadKitConfig, ApiError } from "./client";
+export * from "./types";
+
+/**
+ * @nft-launchpad-kit/sdk — Agent-native NFT issuance.
+ *
+ *   const kit = new LaunchpadKit({ baseUrl, apiKey, chain, wallet });
+ *   const collection = await kit.collections.create({ name, symbol, supply, price });
+ *   const grant = await kit.grants.issue({ collectionAddress: collection.contractAddress, minter, quantity });
+ *   await kit.mint.execute({ collectionAddress: collection.contractAddress, grant });
+ *
+ * Three-level model:
+ *   Level 1 Goal API      — collections.create / grants.issue / metadata.generate / mint.execute
+ *   Level 2 Resource API  — collections.get / collections.list / grants.verify / agents.get
+ *   Level 3 Primitive API — collections.deploy / collections.register
+ */
+export class LaunchpadKit {
+  readonly agents: Agents;
+  readonly collections: Collections;
+  readonly grants: Grants;
+  readonly metadata: Metadata;
+  readonly mint: Mint;
+  readonly config: LaunchpadKitConfig;
+
+  constructor(config: LaunchpadKitConfig) {
+    this.config = config;
+    const client = new ApiClient(config);
+    this.agents = new Agents(client);
+    this.collections = new Collections(client, config);
+    this.grants = new Grants(client, config);
+    this.metadata = new Metadata(client);
+    this.mint = new Mint(client, config);
+  }
+}

--- a/scaffold-alchemy-main/packages/sdk/src/metadata.ts
+++ b/scaffold-alchemy-main/packages/sdk/src/metadata.ts
@@ -1,0 +1,14 @@
+import { ApiClient } from "./client";
+import type { MetadataInput, MetadataResult } from "./types";
+
+/** Metadata — the AI pipeline: generate + pin 1000 token metadata files in ONE request. */
+export class Metadata {
+  constructor(private client: ApiClient) {}
+
+  async generate(input: MetadataInput): Promise<MetadataResult> {
+    return this.client.request("/api/metadata/generate", {
+      method: "POST",
+      body: JSON.stringify(input),
+    });
+  }
+}

--- a/scaffold-alchemy-main/packages/sdk/src/mint.ts
+++ b/scaffold-alchemy-main/packages/sdk/src/mint.ts
@@ -1,0 +1,66 @@
+import { createPublicClient, createWalletClient, http } from "viem";
+import type { Address } from "viem";
+import type { PrivateKeyAccount } from "viem/accounts";
+import { ApiClient, type LaunchpadKitConfig } from "./client";
+import { kitAbi } from "./abis";
+import { viemChain } from "./collections";
+import type { Grant, MintResult } from "./types";
+
+/**
+ * Mint — Level 1: execute a mint with a signed grant.
+ * The minter's wallet pays the mint price + gas; the contract verifies the
+ * signature on-chain (signer, deadline, one-time UID) before minting.
+ * IMPORTANT: the NFT is minted to msg.sender — pass the MINTER's wallet here
+ * (the agent holds the grant, the user executes it).
+ */
+export class Mint {
+  constructor(
+    private client: ApiClient,
+    private config: LaunchpadKitConfig,
+  ) {}
+
+  async execute(input: {
+    collectionAddress: Address;
+    grant: Grant;
+    quantity?: bigint;
+    /** The wallet that executes the mint (pays price + gas). Defaults to the agent wallet. */
+    minter?: PrivateKeyAccount;
+  }): Promise<MintResult> {
+    const chain = viemChain(this.config.chain);
+    const publicClient = createPublicClient({ chain, transport: http(this.config.rpcUrl) });
+    const signer = input.minter ?? this.config.wallet;
+    const walletClient = createWalletClient({ account: signer, chain, transport: http(this.config.rpcUrl) });
+
+    // The signature was issued over the grant's pricePerToken (0 = collection
+    // price). The CONTRACT arg must be exactly what was signed; the VALUE uses
+    // the resolved price. Passing the resolved price here would break the
+    // structHash and revert with BadSignature.
+    const signedPrice = BigInt(input.grant.pricePerToken);
+    const resolvedPrice =
+      signedPrice > 0n
+        ? signedPrice
+        : await publicClient.readContract({
+            address: input.collectionAddress,
+            abi: kitAbi,
+            functionName: "mintPrice",
+          });
+    const quantity = input.quantity ?? 1n;
+
+    const txHash = await walletClient.writeContract({
+      address: input.collectionAddress,
+      abi: kitAbi,
+      functionName: "mintWithSignature712V2",
+      args: [
+        quantity,
+        BigInt(input.grant.maxMint),
+        BigInt(input.grant.deadline),
+        signedPrice,
+        input.grant.uid as `0x${string}`,
+        input.grant.signature as `0x${string}`,
+      ],
+      value: resolvedPrice * quantity,
+    });
+    await publicClient.waitForTransactionReceipt({ hash: txHash });
+    return { txHash };
+  }
+}

--- a/scaffold-alchemy-main/packages/sdk/src/types.ts
+++ b/scaffold-alchemy-main/packages/sdk/src/types.ts
@@ -1,0 +1,128 @@
+/**
+ * @nft-launchpad-kit/sdk — shared types.
+ * Three-level mental model (approved baseline):
+ *   Level 1 Goal API      — create / issue / generate / mint
+ *   Level 2 Resource API  — get / list / verify
+ *   Level 3 Primitive API — deploy / register
+ */
+
+export type ChainId = "sepolia" | "base-sepolia" | "localhost";
+
+export interface CollectionInput {
+  /** Collection name, e.g. "AI Founder Pass". */
+  name: string;
+  /** Ticker symbol, e.g. "AFP". */
+  symbol: string;
+  /** Total supply. */
+  supply: number;
+  /** Price per token in ETH (decimal string), e.g. "0.01". */
+  price: string;
+  /** Per-wallet mint limit (default 5). */
+  maxPerWallet?: number;
+}
+
+export interface RegisterInput extends CollectionInput {
+  contractAddress: string;
+  ownerAddress: string;
+  chainId: number;
+  description?: string;
+  coverImage?: string;
+  baseURI?: string;
+}
+
+/** The platform's collection record (what the API returns). */
+export interface Collection {
+  id: string;
+  name: string;
+  symbol: string;
+  maxSupply: number;
+  mintPrice: string;
+  maxPerWallet: number;
+  contractAddress: string | null;
+  chainId: number;
+  status: string;
+  baseURI: string | null;
+  ownerId: string;
+  createdAt: string;
+}
+
+export interface GrantInput {
+  /** The collection's contract address (from create()/deploy()). */
+  collectionAddress: string;
+  /** The minter's wallet address. */
+  minter: string;
+  /** Number of tokens this grant allows. */
+  quantity: number;
+  /** Max mints this grant allows in total (default 5). */
+  maxMint?: number;
+  /** Unix expiry (default: now + 1h). */
+  deadline?: number;
+  /** Custom per-token price in wei (0 = collection price). */
+  pricePerToken?: number;
+  /** Agent identity to attribute the issuance to (audit trail). */
+  agentAddress?: string;
+}
+
+export interface Grant {
+  /** EIP-712 V2 signature. */
+  signature: string;
+  /** One-time grant id (replay protection). */
+  uid: string;
+  /** Unix expiry. */
+  deadline: number;
+  /** The signer (trusted signer address). */
+  signer: string;
+  /** Echoed from the request for mint(). */
+  quantity: number;
+  maxMint: number;
+  pricePerToken: number;
+}
+
+export interface AgentInput {
+  address: string;
+  name: string;
+  description?: string;
+  capabilities?: string[];
+}
+
+export interface Agent extends AgentInput {
+  id: string;
+  createdAt: string;
+}
+
+export interface AgentDetail extends Agent {
+  grants: AgentGrant[];
+}
+
+export interface AgentGrant {
+  id: string;
+  collectionAddress: string | null;
+  minter: string | null;
+  quantity: number | null;
+  deadline: number | null;
+  uid: string | null;
+  status: string;
+  createdAt: string;
+}
+
+export interface MetadataInput {
+  /** Collection name — tokens are named "<name> #<id>". */
+  name: string;
+  /** Image URL, supports the {id} placeholder. */
+  imageUrl: string;
+  /** Token count (1..10000). */
+  count: number;
+  description?: string;
+  attributes?: { trait_type: string; value: string }[];
+}
+
+export interface MetadataResult {
+  baseUri?: string;
+  count: number;
+  mock?: boolean;
+  dryRun?: boolean;
+}
+
+export interface MintResult {
+  txHash: string;
+}

--- a/scaffold-alchemy-main/packages/sdk/tsconfig.build.json
+++ b/scaffold-alchemy-main/packages/sdk/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/scaffold-alchemy-main/packages/sdk/tsconfig.json
+++ b/scaffold-alchemy-main/packages/sdk/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/scaffold-alchemy-main/yarn.lock
+++ b/scaffold-alchemy-main/yarn.lock
@@ -2598,6 +2598,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nft-launchpad-kit/sdk@workspace:packages/sdk":
+  version: 0.0.0-use.local
+  resolution: "@nft-launchpad-kit/sdk@workspace:packages/sdk"
+  dependencies:
+    "@types/node": ^20.0.0
+    dotenv: ^17.4.2
+    tsx: ^4.19.0
+    typescript: ^5.5.0
+    viem: ^2.13.0
+    vitest: ^4.1.5
+  languageName: unknown
+  linkType: soft
+
 "@ngraveio/bc-ur@npm:^1.0.0, @ngraveio/bc-ur@npm:^1.1.5":
   version: 1.1.13
   resolution: "@ngraveio/bc-ur@npm:1.1.13"
@@ -6974,7 +6987,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^20":
+"@types/node@npm:^20, @types/node@npm:^20.0.0":
   version: 20.19.43
   resolution: "@types/node@npm:20.19.43"
   dependencies:
@@ -11138,6 +11151,13 @@ __metadata:
   version: 16.6.1
   resolution: "dotenv@npm:16.6.1"
   checksum: e8bd63c9a37f57934f7938a9cf35de698097fadf980cb6edb61d33b3e424ceccfe4d10f37130b904a973b9038627c2646a3365a904b4406514ea94d7f1816b69
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^17.4.2":
+  version: 17.4.2
+  resolution: "dotenv@npm:17.4.2"
+  checksum: 217bf2c4696ca40acc13ad063341e9c77cedfdd75e56e4919f4cf2c6333e4f7b38a4b4067e49d006125502a61060cbe85c7eecb0644e4d99ff014693eb7e62c4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Phase 1 执行基线的第一份交付。

## 交付内容

**`@nft-launchpad-kit/sdk`（新 workspace，可发布到 npm）**
- 三层心智模型：Goal（create/issue/generate/mint）· Resource（get/list/verify）· Primitive（deploy/register）
- `new LaunchpadKit({ baseUrl, apiKey, chain, wallet })` —— wallet 构造函数注入
- 内嵌最小 ABI（运行时零 monorepo 依赖）
- 8/8 单元测试 · tsc 干净 · 可 `tsc` 构建出 dist

**服务端最小认证（审核批准的模型）**
- middleware：跨域写端点要求 `Bearer PLATFORM_API_KEY`；同源（自家前端）豁免；读端点公开；开发环境跳过；未配置时保持开放（向后兼容）
- `GET /api/signature/config`：公开签名者地址（SDK 创建集合时信任它）
- 7/7 中间件测试（修了一个真 bug：写路径判断原先不看 HTTP 方法）

**CI**：SDK typecheck + 测试纳入前端 Job

## Dogfood 实测（本地链 + 平台服务 + SDK 全链路）

```
[agent]  ✅ collection Agent Club @ 0xbf9fbff0…
[agent]  ✅ grant issued (uid 0x404ee754…)
[user]   ✅ minted
[verify] uid one-time: true
```

演示中抓到并修复 2 个 SDK 真 bug：
1. **签名价格与执行价格不一致**（传了解析价而非签名原值 → BadSignature）
2. **铸造归属**：mint 执行器必须用铸造者钱包（msg.sender 决定 NFT 归属）

## 下一步（外部依赖）

- **npm 发布**：需要作者 `npm login` 一次，然后我执行 `npm publish`（0.1.0）
- **#15 部署验证**：需要作者配 4 个 GitHub Secrets