### PR TITLE
[chore] 部署无需 Alchemy：公共 RPC 兜底（#15 前置）

### DIFF
--- a/scaffold-alchemy-main/packages/hardhat/hardhat.config.ts
+++ b/scaffold-alchemy-main/packages/hardhat/hardhat.config.ts
@@ -16,14 +16,16 @@ const etherscanApiKey = process.env.ETHERSCAN_API_KEY;
 const alchemyApiKey = process.env.ALCHEMY_API_KEY;
 const alchemyRpcUrl = process.env.ALCHEMY_RPC_URL;
 
-// 支持多种配置格式
+// 支持多种配置格式；最后兜底公共 RPC（无任何 key 也能部署测试网）
 const sepoliaRpcUrl = process.env.SEPOLIA_RPC_URL
   || alchemyRpcUrl
-  || (alchemyApiKey ? `https://eth-sepolia.g.alchemy.com/v2/${alchemyApiKey}` : "");
+  || (alchemyApiKey ? `https://eth-sepolia.g.alchemy.com/v2/${alchemyApiKey}` : "")
+  || "https://ethereum-sepolia.publicnode.com";
 
 // Base Sepolia (#37) — agent economy's home turf; Alchemy supports it by default.
 const baseSepoliaRpcUrl = process.env.BASE_SEPOLIA_RPC_URL
-  || (alchemyApiKey ? `https://base-sepolia.g.alchemy.com/v2/${alchemyApiKey}` : "");
+  || (alchemyApiKey ? `https://base-sepolia.g.alchemy.com/v2/${alchemyApiKey}` : "")
+  || "https://sepolia.base.org";
 
 if (!privateKey) {
   console.warn("PRIVATE_KEY not found in .env file. Deploy to testnet will not work.");


### PR DESCRIPTION
PRIVATE_KEY 已配好（生成的测试钱包）。此改动让 deploy workflow 在只有 PRIVATE_KEY 时也能跑 —— Alchemy/Etherscan/Basescan 都变为可选（验证可后补）。